### PR TITLE
fix: transfers cannot have transaction items

### DIFF
--- a/resources/js/components/TransactionFormStandard.vue
+++ b/resources/js/components/TransactionFormStandard.vue
@@ -254,7 +254,7 @@
                                     ></MathInput>
                                 </div>
                             </div>
-                            <dl class="row">
+                            <dl class="row" v-if="!transactionTypeIsTransfer">
                                 <dt class="col-sm-8">
                                     {{ __('Total amount') }}:
                                 </dt>
@@ -319,6 +319,7 @@
                             :currency="from.account_currency"
                             :payee="payeeId"
                             :remainingAmount="remainingAmountNotAllocated || remainingAmountToPayeeDefault || 0"
+                            :enabled="!transactionTypeIsTransfer"
                     ></transaction-item-container>
                 </div>
             </div>
@@ -644,6 +645,10 @@ export default {
 
             return 0;
         },
+
+        transactionTypeIsTransfer() {
+            return this.form.transaction_type === 'transfer';
+        },
     },
 
     created() {
@@ -761,7 +766,6 @@ export default {
                 // Copy configuration
                 this.form.config.amount_from = this.transaction.config.amount_from;
                 this.form.config.amount_to = this.transaction.config.amount_to;
-
                 this.form.config.account_from_id = this.transaction.config.account_from_id;
                 this.form.config.account_to_id = this.transaction.config.account_to_id;
 
@@ -893,6 +897,11 @@ export default {
                     .val(null).trigger('change')
                     .select2('destroy')
                     .select2(this.getAccountSelectConfig('to'));
+            }
+
+            // Remove all items, if transaction type is transfer
+            if (this.form.transaction_type === 'transfer') {
+                this.form.items = [];
             }
 
             // Update callback options
@@ -1117,7 +1126,7 @@ export default {
             this.syncScheduleStartDate(newDate);
         },
 
-        // Update TO amount with FROM value, if needed
+        // Update TO amount with FROM value, if FROM value changed, and the currencies are the same
         "form.config.amount_from": {
             immediate: true,
             handler(value) {

--- a/resources/js/components/TransactionItemContainer.vue
+++ b/resources/js/components/TransactionItemContainer.vue
@@ -15,12 +15,17 @@
                     class="btn btn-sm btn-success ms-1"
                     dusk="button-add-transaction-item"
                     @click="this.$emit('addTransactionItem')"
-                    :title="__('New transaction item')"><i class="fa fa-plus"></i></button>
+                    :title="__('New transaction item')"
+                    :disabled="!enabled"
+                >
+                    <i class="fa fa-plus"></i>
+                </button>
             </div>
         </div>
         <div class="card-body" id="transaction_item_container">
             <div
                 class="list-group"
+                v-if="enabled"
                 v-for="(item, index) in transactionItems"
                 :key="item.id">
 
@@ -40,7 +45,10 @@
                     :payee="payee"
                 ></transaction-item>
             </div>
-            <div v-if="transactionItems.length === 0">
+            <div v-if="!enabled">
+                {{ __('Transaction items are disabled for this transaction type') }}
+            </div>
+            <div v-if="enabled && transactionItems.length === 0">
                 {{ __('No items added') }}
             </div>
         </div>
@@ -56,7 +64,11 @@
                     type="button"
                     class="btn btn-sm btn-success ms-1"
                     @click="this.$emit('addTransactionItem')"
-                    :title="__('New transaction item')"><span class="fa fa-plus"></span></button>
+                    :title="__('New transaction item')"
+                    :disabled="!enabled"
+                >
+                    <span class="fa fa-plus"></span>
+                </button>
             </div>
         </div>
     </div>
@@ -74,6 +86,10 @@
             currency: String,
             remainingAmount: Number,
             payee: [Number, String],
+            enabled: {
+                type: Boolean,
+                default: true,
+            }
         },
 
         emits: [

--- a/tests/Browser/Pages/Transactions/TransactionFormStandardStandaloneTest.php
+++ b/tests/Browser/Pages/Transactions/TransactionFormStandardStandaloneTest.php
@@ -566,4 +566,31 @@ class TransactionFormStandardStandaloneTest extends DuskTestCase
                 ->assertMissing('#account_from_container > button[data-coreui-target="#newPayeeModal"]');
         });
     }
+
+    public function test_transfer_transaction_type_does_not_allow_to_add_transaction_items()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->user)
+                // Open vanilla form (withdrawal, no preselected account)
+                ->visitRoute('transaction.create', ['type' => 'standard'])
+                // Add amount
+                ->type('#transaction_amount_from', '100')
+                // Add one transaction item
+                ->click('@button-add-transaction-item')
+                // Switch to transfer and confirm dialog
+                ->click('@transaction-type-transfer')
+                ->acceptDialog()
+                // Verify that the "add transaction item" button is disabled
+                ->assertDisabled('@button-add-transaction-item')
+                // Verify that the previously added transaction item is not visible
+                ->assertMissing('#transaction_item_container .transaction_item_row')
+                // Switch back to withdrawal and confirm dialog
+                ->click('@transaction-type-withdrawal')
+                ->acceptDialog()
+                // Verify that the "add transaction item" button is enabled
+                ->assertEnabled('@button-add-transaction-item')
+                // Verify that the previously added transaction item is not visible
+                ->assertMissing('#transaction_item_container .transaction_item_row');
+        });
+    }
 }


### PR DESCRIPTION
As a business rule, the application does not allow transaction items to be added to transfer type transactions. If items were added in the editor for other transaction types, then the change of type removes these.