### PR TITLE
feat: update the OpenAI model used for mail processing

### DIFF
--- a/app/Jobs/ProcessIncomingEmailByAi.php
+++ b/app/Jobs/ProcessIncomingEmailByAi.php
@@ -383,7 +383,7 @@ EOF;
         // Merge the attributes with defaults
         $attributes = array_merge(
             [
-                'model' => 'text-davinci-003',
+                'model' => 'gpt-3.5-turbo-instruct',
                 'max_tokens' => 256,
                 'temperature' => 0.1,
                 'top_p' => 1,


### PR DESCRIPTION
gpt-3.5-turbo-instruct is used instead of text-davinci-003