### PR TITLE
Fix: currency rate data type

### DIFF
--- a/app/Components/FlashMessages.php
+++ b/app/Components/FlashMessages.php
@@ -42,7 +42,7 @@ trait FlashMessages
         self::addMessage($message, 'warning');
     }
 
-    public static function addSimpleDangerMessage($message): void
+    public static function addSimpleErrorMessage($message): void
     {
         self::addMessage($message, 'danger');
     }

--- a/app/Exceptions/CurrencyRateConversionException.php
+++ b/app/Exceptions/CurrencyRateConversionException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Models\Currency;
+use Carbon\Carbon;
+use Exception;
+
+class CurrencyRateConversionException extends Exception
+{
+    protected Currency $currencyFrom;
+    protected ?Currency $currencyTo;
+    protected ?Carbon $date;
+
+    public function __construct($message, $currencyFrom, $currencyTo = null, $date = null)
+    {
+        parent::__construct($message);
+        $this->currencyFrom = $currencyFrom;
+        $this->currencyTo = $currencyTo;
+        $this->date = $date;
+    }
+
+    public function getCurrencyFrom()
+    {
+        return $this->currencyFrom;
+    }
+
+    public function getCurrencyTo()
+    {
+        return $this->currencyTo;
+    }
+
+    public function getDate()
+    {
+        return $this->date;
+    }
+}

--- a/app/Exceptions/CurrencyRateConversionException.php
+++ b/app/Exceptions/CurrencyRateConversionException.php
@@ -8,30 +8,5 @@ use Exception;
 
 class CurrencyRateConversionException extends Exception
 {
-    protected Currency $currencyFrom;
-    protected ?Currency $currencyTo;
-    protected ?Carbon $date;
-
-    public function __construct($message, $currencyFrom, $currencyTo = null, $date = null)
-    {
-        parent::__construct($message);
-        $this->currencyFrom = $currencyFrom;
-        $this->currencyTo = $currencyTo;
-        $this->date = $date;
-    }
-
-    public function getCurrencyFrom()
-    {
-        return $this->currencyFrom;
-    }
-
-    public function getCurrencyTo()
-    {
-        return $this->currencyTo;
-    }
-
-    public function getDate()
-    {
-        return $this->date;
-    }
+    // Custom features to be added here
 }

--- a/app/Http/Controllers/AccountEntityController.php
+++ b/app/Http/Controllers/AccountEntityController.php
@@ -456,7 +456,7 @@ class AccountEntityController extends Controller
             self::addSimpleSuccessMessage(__('Payees merged'));
         } catch (Exception $e) {
             DB::rollback();
-            self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->getMessage());
+            self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->getMessage());
         }
 
         return redirect()->route('account-entity.index', ['type' => 'payee']);

--- a/app/Http/Controllers/AccountGroupController.php
+++ b/app/Http/Controllers/AccountGroupController.php
@@ -123,9 +123,9 @@ class AccountGroupController extends Controller
             return redirect()->route('account-group.index');
         } catch (QueryException $e) {
             if ($e->errorInfo[1] === 1451) {
-                self::addSimpleDangerMessage(__('Account group is in use, cannot be deleted'));
+                self::addSimpleErrorMessage(__('Account group is in use, cannot be deleted'));
             } else {
-                self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
+                self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
             }
         }
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -167,9 +167,9 @@ class CategoryController extends Controller
             return redirect()->route('categories.index');
         } catch (QueryException $e) {
             if ($e->errorInfo[1] === 1451) {
-                self::addSimpleDangerMessage(__('Category is in use, cannot be deleted'));
+                self::addSimpleErrorMessage(__('Category is in use, cannot be deleted'));
             } else {
-                self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
+                self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
             }
 
             return redirect()->back();
@@ -242,7 +242,7 @@ class CategoryController extends Controller
             self::addSimpleSuccessMessage(__('Categories merged'));
         } catch (Exception $e) {
             DB::rollback();
-            self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->getMessage());
+            self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->getMessage());
         }
 
         return redirect()->route('categories.index');

--- a/app/Http/Controllers/CurrencyController.php
+++ b/app/Http/Controllers/CurrencyController.php
@@ -143,7 +143,7 @@ class CurrencyController extends Controller
          */
         // Base currency cannot be deleted
         if ($currency->base) {
-            self::addSimpleDangerMessage(__('Base currency cannot be deleted'));
+            self::addSimpleErrorMessage(__('Base currency cannot be deleted'));
 
             return redirect()->back();
         }
@@ -155,9 +155,9 @@ class CurrencyController extends Controller
             return redirect()->route('currency.index');
         } catch (QueryException $e) {
             if ($e->errorInfo[1] === 1451) {
-                self::addSimpleDangerMessage(__('Currency is in use, cannot be deleted'));
+                self::addSimpleErrorMessage(__('Currency is in use, cannot be deleted'));
             } else {
-                self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
+                self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
             }
 
             return redirect()->back();
@@ -184,7 +184,7 @@ class CurrencyController extends Controller
             $cacheKey = "baseCurrency_forUser_{$currency->user_id}";
             Cache::forget($cacheKey);
 
-            // Get all non-base, updateable currencies of the user, and dispatch the currency rate retrieval job
+            // Get all non-base, updatable currencies of the user, and dispatch the currency rate retrieval job
             $currencies = $currency->user
                 ->currencies()
                 ->notBase()
@@ -194,7 +194,7 @@ class CurrencyController extends Controller
                 GetCurrencyRatesJob::dispatch($currency);
             });
         } else {
-            self::addSimpleDangerMessage(__('Failed to change base currency'));
+            self::addSimpleErrorMessage(__('Failed to change base currency'));
         }
 
         return redirect()->back();

--- a/app/Http/Controllers/CurrencyRateController.php
+++ b/app/Http/Controllers/CurrencyRateController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\CurrencyRateConversionException;
 use App\Http\Traits\CurrencyTrait;
 use App\Models\Currency;
 use App\Models\CurrencyRate;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -84,6 +86,9 @@ class CurrencyRateController extends Controller
         return redirect()->back();
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function retrieveCurrencyRateToBase(Currency $currency, ?Carbon $from = null): RedirectResponse
     {
         /**
@@ -95,11 +100,18 @@ class CurrencyRateController extends Controller
         // Authorize user access to requested currency
         $this->authorize('view', $currency);
 
-        $currency->retrieveCurrencyRateToBase($from);
+        try {
+            $currency->retrieveCurrencyRateToBase($from);
+        } catch (CurrencyRateConversionException|Exception $e) {
+            self::addSimpleErrorMessage($e->getMessage());
+        }
 
         return redirect()->back();
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function retrieveMissingCurrencyRateToBase(Currency $currency): RedirectResponse
     {
         /**
@@ -110,7 +122,11 @@ class CurrencyRateController extends Controller
         // Authorize user access to requested currency
         $this->authorize('view', $currency);
 
-        $currency->retrieveMissingCurrencyRateToBase();
+        try {
+            $currency->retrieveMissingCurrencyRateToBase();
+        } catch (CurrencyRateConversionException $e) {
+            self::addSimpleErrorMessage($e->getMessage());
+        }
 
         return redirect()->back();
     }

--- a/app/Http/Controllers/InvestmentController.php
+++ b/app/Http/Controllers/InvestmentController.php
@@ -184,7 +184,7 @@ class InvestmentController extends Controller
             return redirect()->route('investment.index');
         }
 
-        self::addSimpleDangerMessage($result['error']);
+        self::addSimpleErrorMessage($result['error']);
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/InvestmentGroupController.php
+++ b/app/Http/Controllers/InvestmentGroupController.php
@@ -124,9 +124,9 @@ class InvestmentGroupController extends Controller
             return redirect()->route('investment-group.index');
         } catch (QueryException $e) {
             if ($e->errorInfo[1] === 1451) {
-                self::addSimpleDangerMessage(__('Investment group is in use, cannot be deleted'));
+                self::addSimpleErrorMessage(__('Investment group is in use, cannot be deleted'));
             } else {
-                self::addSimpleDangerMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
+                self::addSimpleErrorMessage(__('Database error:') . ' ' . $e->errorInfo[2]);
             }
 
             return redirect()->back();

--- a/app/Http/Controllers/ReceivedMailController.php
+++ b/app/Http/Controllers/ReceivedMailController.php
@@ -66,7 +66,7 @@ class ReceivedMailController extends Controller
             return redirect()->route('received-mail.index');
         }
 
-        self::addSimpleDangerMessage($result['error']);
+        self::addSimpleErrorMessage($result['error']);
         return redirect()->back();
     }
 }

--- a/app/Http/Requests/FormRequest.php
+++ b/app/Http/Requests/FormRequest.php
@@ -30,7 +30,7 @@ class FormRequest extends IlluminationFormRequest
     {
         $validator->after(function (Validator $validator) {
             foreach ($validator->errors()->all() as $message) {
-                self::addSimpleDangerMessage($message);
+                self::addSimpleErrorMessage($message);
             }
         });
     }

--- a/app/Models/Currency.php
+++ b/app/Models/Currency.php
@@ -169,21 +169,11 @@ class Currency extends Model
 
         // This should never happen, as the base currency falls back to the first currency created by the user.
         if ($baseCurrency === null) {
-            throw new CurrencyRateConversionException(
-                'Base currency not found',
-                $this,
-                null,
-                $dateFrom
-            );
+            throw new CurrencyRateConversionException('Base currency not found');
         }
 
         if ($baseCurrency->id === $this->id) {
-            throw new CurrencyRateConversionException(
-                'Currency is the same as the base currency',
-                $this,
-                $baseCurrency,
-                $dateFrom
-            );
+            throw new CurrencyRateConversionException('Currency is the same as the base currency');
         }
 
         $date = Carbon::parse('yesterday');
@@ -195,12 +185,7 @@ class Currency extends Model
 
         // Verify that both currencies are supported by the API.
         if (!$currencyApi->isCurrencySupported($this->iso_code) || !$currencyApi->isCurrencySupported($baseCurrency->iso_code)) {
-            throw new CurrencyRateConversionException(
-                'One or more of the currencies are not supported by the API',
-                $this,
-                $baseCurrency,
-                $dateFrom
-            );
+            throw new CurrencyRateConversionException('One or more of the currencies are not supported by the API');
         }
 
         $apiData = $currencyApi->getTimeSeries(
@@ -212,12 +197,7 @@ class Currency extends Model
 
         // If rates is not an array with at least one element, throw an exception.
         if (!is_array($apiData) || empty($apiData)) {
-            throw new CurrencyRateConversionException(
-                'No data returned from the API',
-                $this,
-                $baseCurrency,
-                $dateFrom
-            );
+            throw new CurrencyRateConversionException('No data returned from the API');
         }
 
         $validRates = [];
@@ -227,12 +207,7 @@ class Currency extends Model
 
             // Check if the rate is within the valid range.
             if ($sanitizedRate <= 0 || $sanitizedRate >= 9999999999.9999999999) {
-                throw new CurrencyRateConversionException(
-                    'Currency rate is out of the valid range',
-                    $this,
-                    $baseCurrency,
-                    $dateFrom
-                );
+                throw new CurrencyRateConversionException('Currency rate is out of the valid range');
             }
 
             $validRates[$date] = $sanitizedRate;
@@ -263,21 +238,11 @@ class Currency extends Model
 
         // This should never happen, as the base currency falls back to the first currency created by the user.
         if ($baseCurrency === null) {
-            throw new CurrencyRateConversionException(
-                'Base currency not found',
-                $this,
-                null,
-                null
-            );
+            throw new CurrencyRateConversionException('Base currency not found');
         }
 
         if ($baseCurrency->id === $this->id) {
-            throw new CurrencyRateConversionException(
-                'Currency is the same as the base currency',
-                $this,
-                $baseCurrency,
-                null
-            );
+            throw new CurrencyRateConversionException('Currency is the same as the base currency');
         }
 
         // Get the latest date for this currency, compared to the base currency.

--- a/database/migrations/2024_12_26_090003_fix_currency_rate_decimals.php
+++ b/database/migrations/2024_12_26_090003_fix_currency_rate_decimals.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations to increase the allowed value and decimal places for the currency rate.
+     */
+    public function up(): void
+    {
+        Schema::table('currency_rates', function (Blueprint $table) {
+            $table->decimal('rate', 20, 10)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations to the original state.
+     * WARNING: This can result in data loss.
+     */
+    public function down(): void
+    {
+        Schema::table('currency_rates', function (Blueprint $table) {
+            $table->decimal('rate', 8, 4)->change();
+        });
+    }
+};

--- a/tests/Unit/Models/CurrencyTest.php
+++ b/tests/Unit/Models/CurrencyTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Exceptions\CurrencyRateConversionException;
+use App\Models\Currency;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Kantorge\CurrencyExchangeRates\ApiClients\ExchangeRateApiClientInterface;
+use Kantorge\CurrencyExchangeRates\Facades\CurrencyExchangeRates;
+use Tests\TestCase;
+
+class CurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_retrieve_supported_currency_rates_successfully()
+    {
+        // Create a user
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['USD'])
+            ->create([
+            'base' => true
+        ]);
+
+        /** @var Currency $currency */
+        $currency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['EUR'])
+            ->create([
+            'base' => false
+        ]);
+
+        $dateFrom = Carbon::parse('2023-01-01');
+
+        $interface = \Mockery::mock(ExchangeRateApiClientInterface::class);
+        CurrencyExchangeRates::shouldReceive('create')
+            ->andReturn($interface);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($currency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($baseCurrency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('getTimeSeries')
+            ->andReturn([
+                '2023-01-01' => [$baseCurrency->iso_code => 1.2]
+            ]);
+
+        $currency->retrieveCurrencyRateToBase($dateFrom);
+
+        $this->assertDatabaseHas('currency_rates', [
+            'from_id' => $currency->id,
+            'to_id' => $baseCurrency->id,
+            'date' => '2023-01-01',
+            'rate' => 1.2
+        ]);
+    }
+
+    public function test_throws_exception_when_currency_is_same_as_base()
+    {
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()->create([
+            'base' => true
+        ]);
+
+        $this->expectException(CurrencyRateConversionException::class);
+        $this->expectExceptionMessage('Currency is the same as the base currency');
+
+        $baseCurrency->retrieveCurrencyRateToBase();
+    }
+
+    public function test_throws_exception_for_currency_not_supported_by_api()
+    {
+        $this->expectException(CurrencyRateConversionException::class);
+        $this->expectExceptionMessage('One or more of the currencies are not supported by the API');
+
+        // Create a user
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['USD'])
+            ->create([
+                'base' => true
+            ]);
+
+        /** @var Currency $currency */
+        $currency = Currency::factory()
+            ->for($user)
+            ->create([
+                'base' => false,
+                'iso_code' => 'XXX',
+                'name' => 'Unknown currency'
+            ]);
+
+        $interface = \Mockery::mock(ExchangeRateApiClientInterface::class);
+        CurrencyExchangeRates::shouldReceive('create')
+            ->andReturn($interface);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($currency->iso_code)
+            ->andReturn(false);
+
+        $currency->retrieveCurrencyRateToBase();
+    }
+
+    public function test_throws_exception_when_no_data_returned_from_api()
+    {
+        $this->expectException(CurrencyRateConversionException::class);
+        $this->expectExceptionMessage('No data returned from the API');
+
+        // Create a user
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['USD'])
+            ->create([
+                'base' => true
+            ]);
+
+        /** @var Currency $currency */
+        $currency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['EUR'])
+            ->create([
+                'base' => false
+            ]);
+
+        $interface = \Mockery::mock(ExchangeRateApiClientInterface::class);
+        CurrencyExchangeRates::shouldReceive('create')
+            ->andReturn($interface);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($currency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($baseCurrency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('getTimeSeries')
+            ->andReturn([]);
+
+        $currency->retrieveCurrencyRateToBase();
+    }
+
+    public function test_throws_exception_when_rate_is_out_of_range()
+    {
+        $this->expectException(CurrencyRateConversionException::class);
+        $this->expectExceptionMessage('Currency rate is out of the valid range');
+
+        // Create a user
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['USD'])
+            ->create([
+                'base' => true
+            ]);
+
+        /** @var Currency $currency */
+        $currency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['EUR'])
+            ->create([
+                'base' => false
+            ]);
+
+        $dateFrom = Carbon::parse('2023-01-01');
+
+        $interface = \Mockery::mock(ExchangeRateApiClientInterface::class);
+        CurrencyExchangeRates::shouldReceive('create')
+            ->andReturn($interface);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($currency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($baseCurrency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('getTimeSeries')
+            ->andReturn([
+                '2023-01-01' => [$baseCurrency->iso_code => 10000000000.0]
+            ]);
+
+        $currency->retrieveCurrencyRateToBase($dateFrom);
+    }
+
+    public function test_throws_exception_when_rate_is_negative()
+    {
+        $this->expectException(CurrencyRateConversionException::class);
+        $this->expectExceptionMessage('Currency rate is out of the valid range');
+
+        // Create a user
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Currency $baseCurrency */
+        $baseCurrency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['USD'])
+            ->create([
+                'base' => true
+            ]);
+
+        /** @var Currency $currency */
+        $currency = Currency::factory()
+            ->for($user)
+            ->fromIsoCodes(['EUR'])
+            ->create([
+                'base' => false
+            ]);
+
+        $dateFrom = Carbon::parse('2023-01-01');
+
+        $interface = \Mockery::mock(ExchangeRateApiClientInterface::class);
+        CurrencyExchangeRates::shouldReceive('create')
+            ->andReturn($interface);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($currency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('isCurrencySupported')
+            ->with($baseCurrency->iso_code)
+            ->andReturn(true);
+        $interface->shouldReceive('getTimeSeries')
+            ->andReturn([
+                '2023-01-01' => [$baseCurrency->iso_code => -1.0]
+            ]);
+
+        $currency->retrieveCurrencyRateToBase($dateFrom);
+    }
+}

--- a/tests/Unit/Models/CurrencyTest.php
+++ b/tests/Unit/Models/CurrencyTest.php
@@ -86,7 +86,7 @@ class CurrencyTest extends TestCase
         $user = User::factory()->create();
 
         /** @var Currency $baseCurrency */
-        $baseCurrency = Currency::factory()
+        Currency::factory()
             ->for($user)
             ->fromIsoCodes(['USD'])
             ->create([


### PR DESCRIPTION
The originally selected data type for the currency exchange rates was not sufficient for some possibly used values. This PR changes the decimal settings in the database, and also introduces better error handling for the related currency download features.