### PR TITLE
Fix: allow decimal opening balance with enforced boundaries

### DIFF
--- a/app/Http/Requests/AccountEntityRequest.php
+++ b/app/Http/Requests/AccountEntityRequest.php
@@ -41,6 +41,9 @@ class AccountEntityRequest extends FormRequest
                 'config.opening_balance' => [
                     'required',
                     'numeric',
+                    // Fit in signed DECIMAL(30,10) range
+                    'min:-999999999999999999999.9999999999',
+                    'max:999999999999999999999.9999999999',
                 ],
                 'config.account_group_id' => [
                     'required',
@@ -49,7 +52,8 @@ class AccountEntityRequest extends FormRequest
                 ],
                 'config.currency_id' => [
                     'required',
-                    Rule::exists('currencies', 'id')->where(fn ($query) => $query->where('user_id', $this->user()->id)),
+                    Rule::exists('currencies', 'id')
+                        ->where(fn ($query) => $query->where('user_id', $this->user()->id)),
                 ],
             ]);
         }

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
  * App\Models\Account
  *
  * @property int $id
- * @property int $opening_balance
+ * @property float $opening_balance
  * @property int $account_group_id
  * @property int $currency_id
  * @property-read AccountGroup $accountGroup
@@ -83,6 +83,10 @@ class Account extends Model
         'opening_balance',
         'account_group_id',
         'currency_id',
+    ];
+
+    protected $casts = [
+        'opening_balance' => 'float',
     ];
 
     public function config(): MorphOne

--- a/database/migrations/2025_02_08_124255_fix_account_opening_balance_decimals.php
+++ b/database/migrations/2025_02_08_124255_fix_account_opening_balance_decimals.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations to allow the use of decimal values for the opening balance with 10 decimal places,
+     * not breaking the existing bigInteger type.
+     */
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->decimal('opening_balance', 30, 10)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     * WARNING: This can result in data loss.
+     */
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->bigInteger('opening_balance')->default(0)->change();
+        });
+    }
+};


### PR DESCRIPTION
The primary goal of this PR is to enforce the numeric boundaries of the account opening balance values to avoid database errors. However, it also allows the use of decimals instead of integer values.