### PR TITLE
Fix: broken tag-related reporting links

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -55,7 +55,7 @@ class ReportController extends Controller
     }
 
     /**
-     * Display form for searching transactions. Pass any preset filters from query string.
+     * Display form for searching transactions.
      *
      * @param  Request  $request
      * @return View
@@ -67,31 +67,6 @@ class ReportController extends Controller
          * @name('reports.transactions')
          * @middlewares('web', 'auth', 'verified')
          */
-        // Get preset filters from query string
-        $filters = [];
-        if ($request->has('accounts')) {
-            $filters['accounts'] = $request->get('accounts');
-        }
-        if ($request->has('payees')) {
-            $filters['payees'] = $request->get('payees');
-        }
-        if ($request->has('categories')) {
-            $filters['categories'] = $request->get('categories');
-        }
-        if ($request->has('tags')) {
-            $filters['tags'] = $request->get('tags');
-        }
-        if ($request->has('date_from')) {
-            $filters['date_from'] = $request->get('date_from');
-        }
-        if ($request->has('date_to')) {
-            $filters['date_to'] = $request->get('date_to');
-        }
-
-        JavaScript::put([
-            'filters' => $filters,
-        ]);
-
         return view('reports.transactions');
     }
 

--- a/resources/js/components/FindTransactions.vue
+++ b/resources/js/components/FindTransactions.vue
@@ -229,10 +229,10 @@ export default {
             dataTable: null,
             dateFrom: urlParams.get('date_from') || null,
             dateTo: urlParams.get('date_to') || null,
-            selectedAccounts: urlParams.getAll('accounts[]') || [],
-            selectedCategories: urlParams.getAll('categories[]') || [],
-            selectedPayees: urlParams.getAll('payees[]') || [],
-            selectedTags: urlParams.getAll('tags[]') || [],
+            selectedAccounts: this.getUrlParams('accounts'),
+            selectedCategories: this.getUrlParams('categories'),
+            selectedPayees: this.getUrlParams('payees'),
+            selectedTags: this.getUrlParams('tags'),
             presetsReady: {
                 category: false,
                 payee: false,
@@ -335,6 +335,28 @@ export default {
                 .finally(() => {
                     this.busy = false;
                 });
+        },
+
+        /**
+         * This helper function is intended to provide flexibility in getting URL parameters, in terms of various array formats.
+         * E.g. if paramName is 'tags', it should return anything that is in the URL like: 'tags[]' or 'tags[0]'
+         *
+         * @param paramName
+         * @returns {string[]} Array of URL parameters
+         */
+        getUrlParams(paramName) {
+            const urlParams = new URLSearchParams(window.location.search);
+            const regex = new RegExp(`^${paramName}\\[(\\d)?\\]$`);
+
+            let params = [];
+
+            urlParams.forEach((value, key) => {
+                if (regex.test(key)) {
+                  params.push(value);
+                }
+            });
+
+            return params;
         },
 
         /**

--- a/resources/js/search/search.js
+++ b/resources/js/search/search.js
@@ -41,7 +41,7 @@ document.querySelectorAll('#table-search-results-accounts td.transactionCount').
 document.querySelectorAll('#table-search-results-payees td.transactionCount').forEach(getTransactionCount);
 
 // Loop the span placeholder for all the tag results, and get the number of associated transactions for each tag.
-document.querySelectorAll('#list-search-results-tag span.transactionCount').forEach(getTransactionCount);
+document.querySelectorAll('#list-search-results-tags span.transactionCount').forEach(getTransactionCount);
 
 // Loop the span placeholder for all the category results, and get the number of associated transactions for each category.
 document.querySelectorAll('#list-search-results-categories span.transactionCount').forEach(getTransactionCount);

--- a/resources/js/tag/index.js
+++ b/resources/js/tag/index.js
@@ -44,7 +44,7 @@ window.table = $(dataTableSelector).DataTable({
                 return  `<a 
                                 class="btn btn-xs btn-success" 
                                 href="${route('reports.transactions', {tags: [data]})}"
-                                title="${__('Vies associated transactions')}"
+                                title="${__('View associated transactions')}"
                         >
                             <i class="fa-solid fa-magnifying-glass"></i>
                         </a> ` +

--- a/resources/js/tag/index.js
+++ b/resources/js/tag/index.js
@@ -15,7 +15,13 @@ window.table = $(dataTableSelector).DataTable({
     columns: [
         {
             data: "name",
-            title: __("Name")
+            title: __("Name"),
+            render: function (data, type, row) {
+                if (type === 'display') {
+                    return `<a href="${route('reports.transactions', {tags: [row.id]})}" title="${__('View associated transactions')}">${data}</a>`;
+                }
+                return data;
+            }
         },
         {
             data: "active",
@@ -38,7 +44,7 @@ window.table = $(dataTableSelector).DataTable({
                 return  `<a 
                                 class="btn btn-xs btn-success" 
                                 href="${route('reports.transactions', {tags: [data]})}"
-                                title="${__('Show transactions')}"
+                                title="${__('Vies associated transactions')}"
                         >
                             <i class="fa-solid fa-magnifying-glass"></i>
                         </a> ` +

--- a/resources/views/reports/transactions.blade.php
+++ b/resources/views/reports/transactions.blade.php
@@ -8,6 +8,6 @@
 
 @section('content')
     <div id="app">
-        <find-transactions></find-transactions>
+        <find-transactions dusk="component-find-transactions"></find-transactions>
     </div>
 @stop

--- a/tests/Browser/Pages/Reports/FindTransactions/FindTransactionsFilterBehaviorTest.php
+++ b/tests/Browser/Pages/Reports/FindTransactions/FindTransactionsFilterBehaviorTest.php
@@ -81,4 +81,128 @@ class FindTransactionsFilterBehaviorTest extends DuskTestCase
                 ->assertSelected('#dateRangePickerPresets', 'placeholder');
         });
     }
+
+    public function test_tag_selector_defaults_are_loaded_from_the_url(): void
+    {
+        // The default user is assumed to have at least two tags
+        $tag1 = $this->user->tags->first();
+        $tag2 = $this->user->tags->skip(1)->first();
+
+        $this->browse(function (Browser $browser) use ($tag1, $tag2) {
+            // Test with no tags
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', [])
+                ->waitUntilVue('presetsReady.tag', true, '@component-find-transactions')
+                ->assertVue('selectedTags', [], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($tag1, $tag2) {
+            // Test with one tag
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['tags' => [$tag1->id]])
+                ->waitUntilVue('presetsReady.tag', true, '@component-find-transactions')
+                ->assertVue('selectedTags', [$tag1->id], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($tag1, $tag2) {
+            // Test with two tags
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['tags' => [$tag1->id, $tag2->id]])
+                ->waitUntilVue('presetsReady.tag', true, '@component-find-transactions')
+                ->assertVue('selectedTags', [$tag1->id, $tag2->id], '@component-find-transactions');
+        });
+    }
+
+    public function test_category_selector_defaults_are_loaded_from_the_url(): void
+    {
+        // The default user is assumed to have at least two categories
+        $category1 = $this->user->categories->whereNotNull('parent_id')->first();
+        $category2 = $this->user->categories->whereNotNull('parent_id')->skip(1)->first();
+
+        $this->browse(function (Browser $browser) use ($category1, $category2) {
+            // Test with no categories
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', [])
+                ->waitUntilVue('presetsReady.category', true, '@component-find-transactions')
+                ->assertVue('selectedCategories', [], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($category1, $category2) {
+            // Test with one category
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['categories' => [$category1->id]])
+                ->waitUntilVue('presetsReady.category', true, '@component-find-transactions')
+                ->assertVue('selectedCategories', [$category1->id], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($category1, $category2) {
+            // Test with two categories
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['categories' => [$category1->id, $category2->id]])
+                ->waitUntilVue('presetsReady.category', true, '@component-find-transactions')
+                ->assertVue('selectedCategories', [$category1->id, $category2->id], '@component-find-transactions');
+        });
+    }
+
+    public function test_account_selector_defaults_are_loaded_from_the_url(): void
+    {
+        // The default user is assumed to have at least two accounts
+        $account1 = $this->user->accounts->first();
+        $account2 = $this->user->accounts->skip(1)->first();
+
+        $this->browse(function (Browser $browser) use ($account1, $account2) {
+            // Test with no accounts
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', [])
+                ->waitUntilVue('presetsReady.account', true, '@component-find-transactions')
+                ->assertVue('selectedAccounts', [], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($account1, $account2) {
+            // Test with one account
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['accounts' => [$account1->id]])
+                ->waitUntilVue('presetsReady.account', true, '@component-find-transactions')
+                ->assertVue('selectedAccounts', [$account1->id], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($account1, $account2) {
+            // Test with two accounts
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['accounts' => [$account1->id, $account2->id]])
+                ->waitUntilVue('presetsReady.account', true, '@component-find-transactions')
+                ->assertVue('selectedAccounts', [$account1->id, $account2->id], '@component-find-transactions');
+        });
+    }
+
+    public function test_payee_selector_defaults_are_loaded_from_the_url(): void
+    {
+        // The default user is assumed to have at least two payees
+        $payee1 = $this->user->payees->first();
+        $payee2 = $this->user->payees->skip(1)->first();
+
+        $this->browse(function (Browser $browser) use ($payee1, $payee2) {
+            // Test with no payees
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', [])
+                ->waitUntilVue('presetsReady.payee', true, '@component-find-transactions')
+                ->assertVue('selectedPayees', [], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($payee1, $payee2) {
+            // Test with one payee
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['payees' => [$payee1->id]])
+                ->waitUntilVue('presetsReady.payee', true, '@component-find-transactions')
+                ->assertVue('selectedPayees', [$payee1->id], '@component-find-transactions');
+        });
+
+        $this->browse(function (Browser $browser) use ($payee1, $payee2) {
+            // Test with two payees
+            $browser->loginAs($this->user)
+                ->visitRoute('reports.transactions', ['payees' => [$payee1->id, $payee2->id]])
+                ->waitUntilVue('presetsReady.payee', true, '@component-find-transactions')
+                ->assertVue('selectedPayees', [$payee1->id, $payee2->id], '@component-find-transactions');
+        });
+    }
 }


### PR DESCRIPTION
This PR fixes two small issues in connection to tags. 
* The generic search results failed to load the number of associated transactions
* The link from the list of tags did not initially load the transactions associated with the selected tag