### PR TITLE
Feat: added option to load transactions by default in account view

### DIFF
--- a/app/Http/Controllers/API/UserApiController.php
+++ b/app/Http/Controllers/API/UserApiController.php
@@ -53,6 +53,7 @@ class UserApiController extends Controller
                 'locale' => $user->locale,
                 'start_date' => $user->start_date,
                 'end_date' => $user->end_date,
+                'account_details_date_range' => $user->account_details_date_range,
             ]
         ]);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -29,6 +29,7 @@ class UserController extends Controller
         JavaScript::put([
             'languages' => config('app.available_languages'),
             'locales' => config('app.available_locales'),
+            'datePresets' => config('yaffa.account_date_presets'),
         ]);
         return view('user.settings');
     }

--- a/app/Http/Requests/AccountEntityRequest.php
+++ b/app/Http/Requests/AccountEntityRequest.php
@@ -55,6 +55,21 @@ class AccountEntityRequest extends FormRequest
                     Rule::exists('currencies', 'id')
                         ->where(fn ($query) => $query->where('user_id', $this->user()->id)),
                 ],
+                'config.default_date_range' => [
+                    'nullable',
+                    'string',
+                    Rule::in(
+                        array_merge(
+                            ['none'],
+                            ...array_map(fn($group) =>
+                                array_column(
+                                    $group['options'], 'value'),
+                                    config('yaffa.account_date_presets'
+                                )
+                            )    
+                        )
+                    )
+                ],
             ]);
         }
 

--- a/app/Http/Requests/AccountEntityRequest.php
+++ b/app/Http/Requests/AccountEntityRequest.php
@@ -59,15 +59,12 @@ class AccountEntityRequest extends FormRequest
                     'nullable',
                     'string',
                     Rule::in(
-                        array_merge(
-                            ['none'],
-                            ...array_map(fn($group) =>
-                                array_column(
-                                    $group['options'], 'value'),
-                                    config('yaffa.account_date_presets'
-                                )
-                            )    
-                        )
+                        collect(config('yaffa.account_date_presets'))
+                        ->pluck('options')
+                        ->flatten(1)
+                        ->pluck('value')
+                        ->prepend('none')
+                        ->all()
                     )
                 ],
             ]);

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -32,7 +32,22 @@ class UserRequest extends FormRequest
                 'required',
                 'date',
                 'after:start_date',
-            ]
+            ],
+            'account_details_date_range' => [
+                'required',
+                'string',
+                Rule::in(
+                    array_merge(
+                        ['none'],
+                        ...array_map(fn($group) =>
+                            array_column(
+                                $group['options'], 'value'),
+                                config('yaffa.account_date_presets'
+                            )
+                        )    
+                    )
+                )
+            ],
         ];
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -37,15 +37,12 @@ class UserRequest extends FormRequest
                 'required',
                 'string',
                 Rule::in(
-                    array_merge(
-                        ['none'],
-                        ...array_map(fn($group) =>
-                            array_column(
-                                $group['options'], 'value'),
-                                config('yaffa.account_date_presets'
-                            )
-                        )    
-                    )
+                    collect(config('yaffa.account_date_presets'))
+                    ->pluck('options')
+                    ->flatten(1)
+                    ->pluck('value')
+                    ->prepend('none')
+                    ->all()
                 )
             ],
         ];

--- a/app/Http/View/Composers/JavaScriptUserVariablesComposer.php
+++ b/app/Http/View/Composers/JavaScriptUserVariablesComposer.php
@@ -25,6 +25,7 @@ class JavaScriptUserVariablesComposer
                 'translations' => $this->getTranslations(),
                 'start_date' => $user->start_date,
                 'end_date' => $user->end_date,
+                'account_details_date_range' => $user->account_details_date_range,
             ]
         ]);
     }

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\DB;
  * @property float $opening_balance
  * @property int $account_group_id
  * @property int $currency_id
+ * @property string|null $default_date_range
  * @property-read AccountGroup $accountGroup
  * @property-read Collection|Category[] $categoryPreference
  * @property-read int|null $category_preference_count
@@ -83,6 +84,7 @@ class Account extends Model
         'opening_balance',
         'account_group_id',
         'currency_id',
+        'default_date_range',
     ];
 
     protected $casts = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,7 @@ use Spatie\Onboard\Concerns\Onboardable;
  * @property string $locale
  * @property Carbon $start_date
  * @property Carbon $end_date
+ * @property string $account_details_date_range
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, AccountGroup> $accountGroups
@@ -101,6 +102,7 @@ class User extends Authenticatable implements MustVerifyEmail, Onboardable
         'locale',
         'start_date',
         'end_date',
+        'account_details_date_range',
     ];
 
     /**

--- a/config/yaffa.php
+++ b/config/yaffa.php
@@ -14,4 +14,40 @@ return [
     'sandbox_mode' => env('SANDBOX_MODE',false),
     'gtm_container_id' => env('GTM_CONTAINER_ID'),
     'cookieyes_id' => env('COOKIEYES_ID'),
+
+    // These are not actual config values, but a list of supported date presets for account details.
+    // The default / empty value is not added, as it behaves differently in various places.
+    // Translations for the labels are handled in the view.
+    // The actual behavior is also imlemented in the frontend (Vue.js).
+    'account_date_presets' => [
+        [
+            'label' => 'Current interval',
+            'options' => [
+                ['value' => 'thisMonth', 'label' => 'This month'],
+                ['value' => 'thisQuarter', 'label' => 'This quarter'],
+                ['value' => 'thisYear', 'label' => 'This year'],
+                ['value' => 'thisMonthToDate', 'label' => 'This month to date'],
+                ['value' => 'thisQuarterToDate', 'label' => 'This quarter to date'],
+                ['value' => 'thisYearToDate', 'label' => 'This year to date'],
+            ],
+        ],
+        [
+            'label' => 'Previous day(s)',
+            'options' => [
+                ['value' => 'yesterday', 'label' => 'Yesterday'],
+                ['value' => 'previous7Days', 'label' => 'Previous 7 days'],
+                ['value' => 'previous30Days', 'label' => 'Previous 30 days'],
+                ['value' => 'previous90Days', 'label' => 'Previous 90 days'],
+                ['value' => 'previous180Days', 'label' => 'Previous 180 days'],
+                ['value' => 'previous365Days', 'label' => 'Previous 365 days'],
+            ],
+        ],
+        [
+            'label' => 'Previous interval',
+            'options' => [
+                ['value' => 'previousMonth', 'label' => 'Previous month'],
+                ['value' => 'previousMonthToDate', 'label' => 'Previous month to date'],                
+            ],
+        ]
+    ]
 ];

--- a/database/migrations/2025_09_27_122558_add_default_account_date_column.php
+++ b/database/migrations/2025_09_27_122558_add_default_account_date_column.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('account_details_date_range')->default('none')->after('end_date');
+        });
+
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->string('default_date_range')->nullable()->default(null)->after('currency_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('account_details_date_range');
+        });
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->dropColumn('default_date_range');
+        });
+    }
+};

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -74,6 +74,7 @@ const processTransaction = function (transaction) {
 };
 
 let initialLoad = true;
+let isPresetChange = false;
 
 let dtHistory = $(selectorHistoryTable).DataTable({
     ajax: function (_data, callback, _settings) {
@@ -490,6 +491,126 @@ $("#clear_dates").on('click', function () {
     );
 })
 
+// Listener for the date range presets
+document.getElementById('dateRangePickerPresets').addEventListener('change', function (_event) {
+    isPresetChange = true;
+    const preset = this.options[this.selectedIndex].value;
+    const date = new Date();
+    let start;
+    let end;
+    let quarter;
+
+    switch (preset) {
+        case 'thisMonth':
+            start = new Date(date.getFullYear(), date.getMonth(), 1);
+            end = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+            break;
+        case 'thisQuarter':
+            quarter = Math.floor((date.getMonth() + 3) / 3);
+            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
+            end = new Date(date.getFullYear(), quarter * 3, 0);
+            break;
+        case 'thisYear':
+            start = new Date(date.getFullYear(), 0, 1);
+            end = new Date(date.getFullYear(), 12, 0);
+            break;
+        case 'thisMonthToDate':
+            start = new Date(date.getFullYear(), date.getMonth(), 1);
+            end = date;
+            break;
+        case 'thisQuarterToDate':
+            quarter = Math.floor((date.getMonth() + 3) / 3);
+            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
+            end = date;
+            break;
+        case 'thisYearToDate':
+            start = new Date(date.getFullYear(), 0, 1);
+            end = date;
+            break;
+        case  'previousDay':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1);
+            end = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1);
+            break;
+        case 'previous7Days':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 7);
+            end = date;
+            break;
+        case 'previous30Days':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 30);
+            end = date;
+            break;
+        case 'previous90Days':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 90);
+            end = date;
+            break;
+        case 'previous180Days':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 180);
+            end = date;
+            break;
+        case 'previous365Days':
+            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 365);
+            end = date;
+            break;
+        case 'previousMonth':
+            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+            end = new Date(date.getFullYear(), date.getMonth(), 0);
+            break;
+        case 'previousMonthToDate':
+            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+            end = date;
+            break;
+        default:
+            start = {clear: true};
+            end = {clear: true};
+    }
+
+    dateRangePicker.setDates(
+        start,
+        end
+    );
+
+    isPresetChange = false;
+});
+
+let rebuildUrl = function () {
+    let params = [];
+
+    if (isPresetChange) {
+        const preset = document.getElementById('dateRangePickerPresets').value;
+        if (preset && preset !== 'placeholder') {
+            params.push('date_preset=' + preset);
+        }
+    } else {
+
+        const dates = dateRangePicker.getDates('yyyy-mm-dd');
+        // Date from
+        if (dates[0]) {
+            params.push('date_from=' + dates[0]);
+        }
+
+        // Date to
+        if (dates[1]) {
+            params.push('date_to=' + dates[1]);
+        }
+    }
+
+    window.history.pushState('', '', window.location.origin + window.location.pathname + '?' + params.join('&'));
+}
+
+// Attach event listener to date pickers
+document.getElementById('date_from').addEventListener('changeDate', function() {
+    if (!isPresetChange) {
+        document.getElementById('dateRangePickerPresets').value = 'placeholder';
+    }
+    rebuildUrl();
+});
+document.getElementById('date_to').addEventListener('changeDate', function() {
+    if (!isPresetChange) {
+        document.getElementById('dateRangePickerPresets').value = 'placeholder';
+    }
+    rebuildUrl();
+});
+
 // Set initial dates
 if (filters.date_from || filters.date_to) {
     const start = (filters.date_from ? filters.date_from : {clear: true});
@@ -502,6 +623,17 @@ if (filters.date_from || filters.date_to) {
 
     presetFilters.date_from = true;
     presetFilters.date_to = true;
+    // If all preset filters are ready, reload table data
+    if (presetFilters.ready()) {
+        reloadTable();
+    }
+} else if (filters.date_preset) {
+    // If date preset is set, apply it
+    document.getElementById('dateRangePickerPresets').value = filters.date_preset;    
+    const event = new Event('change');
+    document.getElementById('dateRangePickerPresets').dispatchEvent(event);
+
+    presetFilters.date_preset = true;
     // If all preset filters are ready, reload table data
     if (presetFilters.ready()) {
         reloadTable();
@@ -618,82 +750,6 @@ window.addEventListener('transaction-created', function (event) {
 
     // TODO: is there a more efficient way to do this instead of reloading the entire table?
 });
-
-// Listener for the date range presets
-document.getElementById('dateRangePickerPresets').addEventListener('change', function (_event) {
-    const preset = this.options[this.selectedIndex].value;
-    const date = new Date();
-    let start;
-    let end;
-    let quarter;
-
-    switch (preset) {
-        case 'thisMonth':
-            start = new Date(date.getFullYear(), date.getMonth(), 1);
-            end = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-            break;
-        case 'thisQuarter':
-            quarter = Math.floor((date.getMonth() + 3) / 3);
-            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
-            end = new Date(date.getFullYear(), quarter * 3, 0);
-            break;
-        case 'thisYear':
-            start = new Date(date.getFullYear(), 0, 1);
-            end = new Date(date.getFullYear(), 12, 0);
-            break;
-        case 'thisMonthToDate':
-            start = new Date(date.getFullYear(), date.getMonth(), 1);
-            end = date;
-            break;
-        case 'thisQuarterToDate':
-            quarter = Math.floor((date.getMonth() + 3) / 3);
-            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
-            end = date;
-            break;
-        case 'thisYearToDate':
-            start = new Date(date.getFullYear(), 0, 1);
-            end = date;
-            break;
-        case 'previousMonth':
-            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
-            end = new Date(date.getFullYear(), date.getMonth(), 0);
-            break;
-        case 'previousMonthToDate':
-            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
-            end = date;
-            break;
-        default:
-            start = {clear: true};
-            end = {clear: true};
-    }
-
-    dateRangePicker.setDates(
-        start,
-        end
-    );
-
-});
-
-// Attach event listener to filters
-let rebuildUrl = function () {
-    let params = [];
-
-    const dates = dateRangePicker.getDates('yyyy-mm-dd');
-    // Date from
-    if (dates[0]) {
-        params.push('date_from=' + dates[0]);
-    }
-
-    // Date to
-    if (dates[1]) {
-        params.push('date_to=' + dates[1]);
-    }
-
-    window.history.pushState('', '', window.location.origin + window.location.pathname + '?' + params.join('&'));
-}
-
-document.getElementById('date_from').addEventListener('changeDate', rebuildUrl);
-document.getElementById('date_to').addEventListener('changeDate', rebuildUrl);
 
 // Add event listener for the cache update button
 document.getElementById('recalculateMonthlyCachedData').addEventListener('click', function () {

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -6,6 +6,8 @@ import * as helpers from '../helpers';
 
 import DateRangePicker from 'vanillajs-datepicker/DateRangePicker';
 
+import presetCalculators from '../presetDates';
+
 const selectorScheduleTable = '#scheduleTable';
 const selectorHistoryTable = '#historyTable';
 
@@ -364,8 +366,8 @@ let getAccountBalance = function () {
                 elementOpeningBalance.innerHTML =
                     elementCurrentCash.innerHTML =
                         elementCurrentBalance.innerHTML =
-                            `<i 
-                                 class="text-warning fa-solid fa-triangle-exclamation" 
+                            `<i
+                                 class="text-warning fa-solid fa-triangle-exclamation"
                                  title="${response.data.message}"
                          ></i>`;
 
@@ -412,8 +414,8 @@ let getAccountBalance = function () {
             elementOpeningBalance.innerHTML =
                 elementCurrentCash.innerHTML =
                     elementCurrentBalance.innerHTML =
-                        `<i 
-                                 class="text-danger fa-solid fa-triangle-exclamation" 
+                        `<i
+                                 class="text-danger fa-solid fa-triangle-exclamation"
                                  title="${__('Error while retrieving data')}"
                          ></i>`;
 
@@ -498,70 +500,16 @@ document.getElementById('dateRangePickerPresets').addEventListener('change', fun
     const date = new Date();
     let start;
     let end;
-    let quarter;
 
-    switch (preset) {
-        case 'thisMonth':
-            start = new Date(date.getFullYear(), date.getMonth(), 1);
-            end = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-            break;
-        case 'thisQuarter':
-            quarter = Math.floor((date.getMonth() + 3) / 3);
-            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
-            end = new Date(date.getFullYear(), quarter * 3, 0);
-            break;
-        case 'thisYear':
-            start = new Date(date.getFullYear(), 0, 1);
-            end = new Date(date.getFullYear(), 12, 0);
-            break;
-        case 'thisMonthToDate':
-            start = new Date(date.getFullYear(), date.getMonth(), 1);
-            end = date;
-            break;
-        case 'thisQuarterToDate':
-            quarter = Math.floor((date.getMonth() + 3) / 3);
-            start = new Date(date.getFullYear(), (quarter - 1) * 3, 1);
-            end = date;
-            break;
-        case 'thisYearToDate':
-            start = new Date(date.getFullYear(), 0, 1);
-            end = date;
-            break;
-        case  'previousDay':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1);
-            end = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1);
-            break;
-        case 'previous7Days':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 7);
-            end = date;
-            break;
-        case 'previous30Days':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 30);
-            end = date;
-            break;
-        case 'previous90Days':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 90);
-            end = date;
-            break;
-        case 'previous180Days':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 180);
-            end = date;
-            break;
-        case 'previous365Days':
-            start = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 365);
-            end = date;
-            break;
-        case 'previousMonth':
-            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
-            end = new Date(date.getFullYear(), date.getMonth(), 0);
-            break;
-        case 'previousMonthToDate':
-            start = new Date(date.getFullYear(), date.getMonth() - 1, 1);
-            end = date;
-            break;
-        default:
-            start = {clear: true};
-            end = {clear: true};
+    // Get the start and end dates based on the selected preset and the external calculator functions
+    const calculator = presetCalculators[preset];
+    if (calculator) {
+        const dates = calculator(date);
+        start = dates.start;
+        end = dates.end;
+    } else {
+        start = {clear: true};
+        end = {clear: true};
     }
 
     dateRangePicker.setDates(
@@ -629,7 +577,7 @@ if (filters.date_from || filters.date_to) {
     }
 } else if (filters.date_preset) {
     // If date preset is set, apply it
-    document.getElementById('dateRangePickerPresets').value = filters.date_preset;    
+    document.getElementById('dateRangePickerPresets').value = filters.date_preset;
     const event = new Event('change');
     document.getElementById('dateRangePickerPresets').dispatchEvent(event);
 

--- a/resources/js/presetDates.js
+++ b/resources/js/presetDates.js
@@ -1,0 +1,66 @@
+const presetCalculators = {
+    thisMonth: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), 1),
+        end: new Date(date.getFullYear(), date.getMonth() + 1, 0),
+    }),
+    thisQuarter: (date) => {
+        const quarter = Math.floor((date.getMonth() + 3) / 3);
+        return {
+            start: new Date(date.getFullYear(), (quarter - 1) * 3, 1),
+            end: new Date(date.getFullYear(), quarter * 3, 0),
+        };
+    },
+    thisYear: (date) => ({
+        start: new Date(date.getFullYear(), 0, 1),
+        end: new Date(date.getFullYear(), 12, 0),
+    }),
+    thisMonthToDate: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), 1),
+        end: date,
+    }),
+    thisQuarterToDate: (date) => {
+        const quarter = Math.floor((date.getMonth() + 3) / 3);
+        return {
+            start: new Date(date.getFullYear(), (quarter - 1) * 3, 1),
+            end: date,
+        };
+    },
+    thisYearToDate: (date) => ({
+        start: new Date(date.getFullYear(), 0, 1),
+        end: date,
+    }),
+    yesterday: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1),
+        end: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1),
+    }),
+    previous7Days: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 7),
+        end: date,
+    }),
+    previous30Days: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 30),
+        end: date,
+    }),
+    previous90Days: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 90),
+        end: date,
+    }),
+    previous180Days: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 180),
+        end: date,
+    }),
+    previous365Days: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 365),
+        end: date,
+    }),
+    previousMonth: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth() - 1, 1),
+        end: new Date(date.getFullYear(), date.getMonth(), 0),
+    }),
+    previousMonthToDate: (date) => ({
+        start: new Date(date.getFullYear(), date.getMonth() - 1, 1),
+        end: date,
+    }),
+};
+
+export default presetCalculators;

--- a/resources/js/user/UserSettings.vue
+++ b/resources/js/user/UserSettings.vue
@@ -166,6 +166,40 @@
                         <HasError field="end_date" :form="form" />
                     </div>
                 </div>
+                <div class="row mb-3">
+                    <label for="end_date" class="col-form-label col-sm-3">
+                        {{ __('Default date range for account details') }}
+                    </label>
+                    <div class="col-sm-9">
+                        <div class="input-group">
+                            <select
+                                    class="form-select"
+                                    id="account_details_date_range"
+                                    name="account_details_date_range"
+                                    v-model="form.account_details_date_range"
+                            >
+                                <option value="none">{{ __("Don't load data by default") }}</option>
+                                <optgroup v-for="(group) in datePresets" :label="group.label">
+                                    <option v-for="option in group.options" :value="option.value">
+                                        {{ option.label }}
+                                    </option>
+                                </optgroup>
+                            </select>
+                            <span
+                                    class="input-group-text btn btn-info"
+                                    data-coreui-toggle="tooltip"
+                                    data-coreui-placement="top"
+                                    :title="__('The default date range to load transactions from when opening account details. This can be changed on the fly in the account details view.')"
+                            >
+                                <i
+                                        class="fa fa-info-circle"
+                                ></i>
+                            </span>
+                        </div>
+                        <HasError field="language" :form="form" />
+                    </div>
+
+                </div>
             </div>
             <div class="card-footer">
                 <Button
@@ -189,6 +223,10 @@
             type: Object,
             default: window.locales
         },
+        datePresets: {
+            type: Object,
+            default: window.datePresets
+        }
     });
 </script>
 <script>
@@ -208,7 +246,8 @@
                 locale: window.YAFFA.locale,
                 end_date: window.YAFFA.end_date,
                 start_date: window.YAFFA.start_date,
-            })
+                account_details_date_range: window.YAFFA.account_details_date_range || 'none',
+            }),                   
         }),
         mounted() {
             // Finally, initialize tooltips
@@ -233,6 +272,7 @@
                             window.YAFFA.locale = response.data.data.locale;
                             window.YAFFA.start_date = response.data.data.start_date;
                             window.YAFFA.end_date = response.data.data.end_date;
+                            window.YAFFA.account_details_date_range = response.data.data.account_details_date_range;
 
                             // Emit a custom event to global scope about the result
                             _vue.showToast(

--- a/resources/js/user/UserSettings.vue
+++ b/resources/js/user/UserSettings.vue
@@ -167,7 +167,7 @@
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label for="end_date" class="col-form-label col-sm-3">
+                    <label for="account_details_date_range" class="col-form-label col-sm-3">
                         {{ __('Default date range for account details') }}
                     </label>
                     <div class="col-sm-9">
@@ -196,7 +196,7 @@
                                 ></i>
                             </span>
                         </div>
-                        <HasError field="language" :form="form" />
+                        <HasError field="account_details_date_range" :form="form" />
                     </div>
 
                 </div>
@@ -247,7 +247,7 @@
                 end_date: window.YAFFA.end_date,
                 start_date: window.YAFFA.start_date,
                 account_details_date_range: window.YAFFA.account_details_date_range || 'none',
-            }),                   
+            }),
         }),
         mounted() {
             // Finally, initialize tooltips

--- a/resources/views/account/form.blade.php
+++ b/resources/views/account/form.blade.php
@@ -169,6 +169,42 @@
                             >{{old('alias', $account->alias ?? '' )}}</textarea>
                 </div>
             </div>
+
+            <div class="row mb-3">
+                <label for="default_date_range" class="col-form-label col-sm-3">
+                    {{ __('Default date range for account details') }}
+                </label>
+                <div class="col-sm-9">
+                    <select
+                        class="form-select"
+                        id="default_date_range"
+                        name="config[default_date_range]"
+                    >
+                        <option value="">{{ __('Inherit user setting') }}</option>
+                        <option value="none">{{ __("Don't load data by default") }}</option>
+                        @foreach (config('yaffa.account_date_presets') as $group)
+                            <optgroup label="{{ __($group['label']) }}">
+                                @foreach ($group['options'] as $option)
+                                    <option
+                                        value="{{ $option['value'] }}"
+                                        @if (old())
+                                            @if (old('config.default_date_range') == $option['value'])
+                                                selected="selected"
+                                            @endif
+                                        @elseif(isset($account))
+                                            @if (($account['config']['default_date_range'] ?? null) == $option['value'])
+                                                selected="selected"
+                                            @endif
+                                        @endif
+                                    >
+                                        {{ __($option['label']) }}
+                                    </option>
+                                @endforeach
+                            </optgroup>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
         </div>
         <div class="card-footer">
             @csrf

--- a/resources/views/account/show.blade.php
+++ b/resources/views/account/show.blade.php
@@ -149,14 +149,13 @@
                         <div class="col-12">
                             <select id="dateRangePickerPresets" class="form-select">
                                 <option value="placeholder">{{ __('Select preset') }}</option>
-                                <option value="thisMonth">{{ __('This month') }}</option>
-                                <option value="thisQuarter">{{ __('This quarter') }}</option>
-                                <option value="thisYear">{{ __('This year') }}</option>
-                                <option value="thisMonthToDate">{{ __('This month to date') }}</option>
-                                <option value="thisQuarterToDate">{{ __('This quarter to date') }}</option>
-                                <option value="thisYearToDate">{{ __('This year to date') }}</option>
-                                <option value="previousMonth">{{ __('Previous month') }}</option>
-                                <option value="previousMonthToDate">{{ __('Previous month to date') }}</option>
+                                @foreach(config('yaffa.account_date_presets') as $group)
+                                    <optgroup label="{{ __($group['label']) }}">
+                                        @foreach($group['options'] as $option)
+                                            <option value="{{ $option['value'] }}">{{ __($option['label']) }}</option>
+                                        @endforeach
+                                    </optgroup>
+                                @endforeach
                             </select>
                         </div>
                     </div>

--- a/tests/Browser/Pages/Accounts/AccountShowTest.php
+++ b/tests/Browser/Pages/Accounts/AccountShowTest.php
@@ -353,7 +353,7 @@ class AccountShowTest extends DuskTestCase
                 // Load the account show page for the Wallet account with a preset parameter that takes precedence over both the account and user settings
                 ->visitRoute('account-entity.show', [
                     'account_entity' => $account->id,
-                    'preset' => 'previous7Days',
+                    'date_preset' => 'previous7Days',
                 ])
                 // Wait for the page to load, including the table content
                 ->waitFor('#historyTable')

--- a/tests/Unit/Http/Controllers/API/UserApiControllerTest.php
+++ b/tests/Unit/Http/Controllers/API/UserApiControllerTest.php
@@ -19,6 +19,7 @@ class UserApiControllerTest extends TestCase
             'locale' => 'en-US',
             'start_date' => '2020-01-01',
             'end_date' => '2020-12-31',
+            'account_details_date_range' => 'none',
         ]);
         $this->actingAs($user);
 
@@ -27,6 +28,7 @@ class UserApiControllerTest extends TestCase
             'locale' => 'hu-HU',
             'start_date' => '2021-01-01',
             'end_date' => '2021-12-31',
+            'account_details_date_range' => 'yesterday',
         ]);
 
         $response->assertStatus(200)
@@ -37,6 +39,7 @@ class UserApiControllerTest extends TestCase
                     'locale' => 'hu-HU',
                     'start_date' => '2021-01-01T00:00:00.000000Z',
                     'end_date' => '2021-12-31T00:00:00.000000Z',
+                    'account_details_date_range' => 'yesterday',
                 ],
             ]);
 
@@ -46,6 +49,7 @@ class UserApiControllerTest extends TestCase
             'locale' => 'hu-HU',
             'start_date' => '2021-01-01',
             'end_date' => '2021-12-31',
+            'account_details_date_range' => 'yesterday',
         ]);
     }
 
@@ -62,6 +66,7 @@ class UserApiControllerTest extends TestCase
             'locale' => $user->locale,
             'start_date' => $user->start_date->format('Y-m-d'),
             'end_date' => $user->start_date->addYear()->format('Y-m-d'),
+            'account_details_date_range' => $user->account_details_date_range,
         ]);
 
         $response->assertStatus(200)
@@ -83,6 +88,7 @@ class UserApiControllerTest extends TestCase
             'locale' => $user->locale,
             'start_date' => $user->start_date->format('Y-m-d'),
             'end_date' => $user->end_date->format('Y-m-d'),
+            'account_details_date_range' => $user->account_details_date_range,
         ]);
 
         $response->assertStatus(200)
@@ -104,6 +110,7 @@ class UserApiControllerTest extends TestCase
             'locale' => 'en-US', // same as current
             'start_date' => $user->start_date->format('Y-m-d'), // same as current
             'end_date' => $user->end_date->format('Y-m-d'), // same as current
+            'account_details_date_range' => $user->account_details_date_range, // same as current
         ]);
 
         $response->assertStatus(200)


### PR DESCRIPTION
New settings are introduced both on user level and on account level to load transactions by default for a predefined interval on the main account view. It can be set as a generic behavior, or customized on account level. It is disabled by default.

Closes #323 