### PR TITLE
docker: stream apache/php errors to container stdout and stderr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,7 +137,7 @@ TELESCOPE_ENABLED=FALSE
 
 # You can specify the log channel to be used for logging
 LOG_CHANNEL=stack
-LOG_STACK=single
+LOG_STACK=single,stderr
 
 # The minimum log level to be written to the log files
 LOG_LEVEL=error

--- a/.env.example
+++ b/.env.example
@@ -137,7 +137,13 @@ TELESCOPE_ENABLED=FALSE
 
 # You can specify the log channel to be used for logging
 LOG_CHANNEL=stack
-LOG_STACK=single,stderr
+LOG_STACK=single
+# When running in a container runtime, you can route Laravel logs to the
+# container's stderr stream so they show up in `docker logs`:
+#   LOG_STACK=stderr           # stream-only, recommended for prod containers
+#   LOG_STACK=single,stderr    # also keep the file in storage/logs/laravel.log
+# Note: the bundled docker-compose.yml already sets LOG_STACK=stderr on the
+# `app` and `scheduler` services, which overrides this value inside containers.
 
 # The minimum log level to be written to the log files
 LOG_LEVEL=error

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y \
 RUN a2enmod rewrite
 
 # Stream Apache logs to container stdout/stderr for centralized collection.
-RUN sed -i 's|ErrorLog ${APACHE_LOG_DIR}/error.log|ErrorLog /proc/self/fd/2|g' /etc/apache2/apache2.conf \
-    && sed -i 's|CustomLog ${APACHE_LOG_DIR}/access.log combined|CustomLog /proc/self/fd/1 combined|g' /etc/apache2/sites-available/000-default.conf
+RUN sed -i 's|ErrorLog ${APACHE_LOG_DIR}/error.log|ErrorLog /dev/stderr|g' /etc/apache2/apache2.conf /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's|CustomLog ${APACHE_LOG_DIR}/access.log combined|CustomLog /dev/stdout combined|g' /etc/apache2/sites-available/000-default.conf
 
 # Install Composer globally (will be cached until the next change)
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y \
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Stream Apache logs to container stdout/stderr for centralized collection.
+RUN sed -i 's|ErrorLog ${APACHE_LOG_DIR}/error.log|ErrorLog /proc/self/fd/2|g' /etc/apache2/apache2.conf \
+    && sed -i 's|CustomLog ${APACHE_LOG_DIR}/access.log combined|CustomLog /proc/self/fd/1 combined|g' /etc/apache2/sites-available/000-default.conf
+
 # Install Composer globally (will be cached until the next change)
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -43,6 +47,9 @@ COPY --from=assets /app/public/build /var/www/html/public/build
 # Set environment variables to force production mode
 ENV APP_ENV=production \
     APP_DEBUG=false
+
+# Production-safe PHP error logging to stderr (visible in container logs).
+COPY ./docker/php-logging.ini /usr/local/etc/php/conf.d/zz-php-logging.ini
 
 # Install dependencies via Composer
 RUN composer install --no-dev --no-interaction --no-progress

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y \
 RUN a2enmod rewrite
 
 # Stream Apache logs to container stdout/stderr for centralized collection.
-RUN sed -i 's|ErrorLog ${APACHE_LOG_DIR}/error.log|ErrorLog /dev/stderr|g' /etc/apache2/apache2.conf /etc/apache2/sites-available/000-default.conf \
-    && sed -i 's|CustomLog ${APACHE_LOG_DIR}/access.log combined|CustomLog /dev/stdout combined|g' /etc/apache2/sites-available/000-default.conf
+COPY ./docker/apache-logging.conf /etc/apache2/conf-available/docker-logging.conf
+RUN a2enconf docker-logging
 
 # Install Composer globally (will be cached until the next change)
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -58,9 +58,10 @@ RUN composer install --no-dev --no-interaction --no-progress
 RUN chown -R www-data:www-data /var/www/html \
     && chmod -R 755 /var/www/html/storage /var/www/html/bootstrap/cache
 
-# Update the Apache configuration to use the new document root
+# Replace the default Apache vhost with one that points at Laravel's public/ directory.
+# ErrorLog/CustomLog are inherited from conf-enabled/docker-logging.conf above.
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
-RUN sed -i 's|/var/www/html|/var/www/html/public|g' /etc/apache2/sites-available/000-default.conf /etc/apache2/apache2.conf
+COPY ./docker/apache-vhost.conf /etc/apache2/sites-available/000-default.conf
 
 # Expose the default HTTP port
 EXPOSE 80

--- a/docker/apache-logging.conf
+++ b/docker/apache-logging.conf
@@ -1,0 +1,2 @@
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 combined

--- a/docker/apache-vhost.conf
+++ b/docker/apache-vhost.conf
@@ -1,0 +1,8 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html/public
+
+	# ErrorLog and CustomLog are intentionally not set here so that the vhost
+	# inherits the server-level directives from conf-enabled/docker-logging.conf,
+	# which route Apache logs to the container's stdout/stderr streams.
+</VirtualHost>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       - .env
     environment:
       RUNS_SCHEDULER: FALSE
+      # Stream Laravel application logs to the container's stderr so they show up
+      # in `docker logs`. Overrides LOG_STACK from .env. Remove this line if you
+      # prefer file-based logging into the yaffa_storage volume.
+      LOG_STACK: stderr
     volumes:
       - yaffa_storage:/var/www/html/storage # Yaffa storage for logs and planned future upload features
     depends_on:
@@ -62,6 +66,8 @@ services:
       - .env
     environment:
       RUNS_SCHEDULER: TRUE
+      # See note in the `app` service above.
+      LOG_STACK: stderr
     volumes:
       - yaffa_storage:/var/www/html/storage
     depends_on:

--- a/docker/php-logging.ini
+++ b/docker/php-logging.ini
@@ -1,0 +1,4 @@
+log_errors=On
+error_log=/proc/self/fd/2
+display_errors=Off
+display_startup_errors=Off


### PR DESCRIPTION
This branch improves production log visibility in containerized deployments by routing Apache and PHP logs to container `stdout/stderr`, so `5xx` errors are visible via `docker logs` without enabling debug mode.

### Scope

- Apache logs:
  - `ErrorLog` -> `stderr` (`/proc/self/fd/2`)
  - `CustomLog` -> `stdout` (`/proc/self/fd/1`)
- PHP logs:
  - `log_errors=On`
  - `error_log=/proc/self/fd/2`
- Production safety preserved:
  - `display_errors=Off`
  - `display_startup_errors=Off`

### Why

Previously, runtime failures (e.g. HTTP 500) could be hard to diagnose because only access logs were easily available from the container. This change makes application and runtime errors observable through standard container logging streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated logging so Apache and PHP application logs are routed to container stdout/stderr for better visibility in containerized deployments.
  * Changed the default LOG_STACK to include stderr, and docker compose now sets LOG_STACK=stderr for relevant services.

* **Documentation**
  * Added inline docs explaining LOG_STACK options and container-focused examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->