### PR TITLE
ci: add optional contributor docker build workflow

### DIFF
--- a/.github/workflows/docker-build-contributor.yml
+++ b/.github/workflows/docker-build-contributor.yml
@@ -1,0 +1,99 @@
+name: Optional Docker build for contributors
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source branch to build (e.g. feat/my-change)'
+        required: true
+        default: 'develop'
+      platforms:
+        description: 'Platforms to build (comma-separated)'
+        required: false
+        default: 'linux/amd64'
+      image_name:
+        description: 'Target image name (default: ghcr.io/<repo-owner>/yaffa)'
+        required: false
+        default: ''
+      publish_latest:
+        description: 'Publish latest tag (true/false)'
+        required: false
+        default: 'false'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_branch }}
+
+      - name: Prepare build metadata
+        run: |
+          BRANCH=$(echo "${{ github.event.inputs.source_branch }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          DATE=$(date +%Y%m%d-%H%M)
+          echo "DOCKER_VERSION_TAG=${BRANCH}-${DATE}" >> $GITHUB_ENV
+          echo "SOURCE_BRANCH=${{ github.event.inputs.source_branch }}" >> $GITHUB_ENV
+          echo "BUILD_PLATFORMS=${{ github.event.inputs.platforms }}" >> $GITHUB_ENV
+          echo "PUBLISH_LATEST=${{ github.event.inputs.publish_latest }}" >> $GITHUB_ENV
+
+          if [ -n "${{ github.event.inputs.image_name }}" ]; then
+            echo "IMAGE_NAME=${{ github.event.inputs.image_name }}" >> $GITHUB_ENV
+          else
+            OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+            echo "IMAGE_NAME=ghcr.io/${OWNER}/yaffa" >> $GITHUB_ENV
+          fi
+
+      - name: Print build info
+        run: |
+          echo "event: ${{ github.event_name }}"
+          echo "source branch: ${{ env.SOURCE_BRANCH }}"
+          echo "version tag: ${{ env.DOCKER_VERSION_TAG }}"
+          echo "platforms: ${{ env.BUILD_PLATFORMS }}"
+          echo "image: ${{ env.IMAGE_NAME }}"
+          echo "publish latest: ${{ env.PUBLISH_LATEST }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure Docker cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ github.ref_name }}-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.DOCKER_VERSION_TAG }}
+            ${{ env.PUBLISH_LATEST == 'true' && format('{0}:latest', env.IMAGE_NAME) || '' }}
+          build-args: |
+            BRANCH=${{ env.SOURCE_BRANCH }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache to current path
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker-build-contributor.yml
+++ b/.github/workflows/docker-build-contributor.yml
@@ -16,9 +16,10 @@ on:
         required: false
         default: ''
       publish_latest:
-        description: 'Publish latest tag (true/false)'
+        description: 'Publish latest tag'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
 
 jobs:
   docker:
@@ -26,6 +27,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      SOURCE_BRANCH_INPUT: ${{ github.event.inputs.source_branch }}
+      PLATFORMS_INPUT: ${{ github.event.inputs.platforms }}
+      IMAGE_NAME_INPUT: ${{ github.event.inputs.image_name }}
+      PUBLISH_LATEST_INPUT: ${{ github.event.inputs.publish_latest }}
+      REPO_OWNER_INPUT: ${{ github.repository_owner }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -34,19 +41,29 @@ jobs:
 
       - name: Prepare build metadata
         run: |
-          BRANCH=$(echo "${{ github.event.inputs.source_branch }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          BRANCH=$(printf '%s' "$SOURCE_BRANCH_INPUT" | sed 's/[^a-zA-Z0-9._-]/-/g')
           DATE=$(date +%Y%m%d-%H%M)
-          echo "DOCKER_VERSION_TAG=${BRANCH}-${DATE}" >> $GITHUB_ENV
-          echo "SOURCE_BRANCH=${{ github.event.inputs.source_branch }}" >> $GITHUB_ENV
-          echo "BUILD_PLATFORMS=${{ github.event.inputs.platforms }}" >> $GITHUB_ENV
-          echo "PUBLISH_LATEST=${{ github.event.inputs.publish_latest }}" >> $GITHUB_ENV
+          DOCKER_VERSION_TAG="${BRANCH}-${DATE}"
+          echo "DOCKER_VERSION_TAG=${DOCKER_VERSION_TAG}" >> "$GITHUB_ENV"
+          echo "SOURCE_BRANCH=${SOURCE_BRANCH_INPUT}" >> "$GITHUB_ENV"
+          echo "SOURCE_BRANCH_SAFE=${BRANCH}" >> "$GITHUB_ENV"
+          echo "BUILD_PLATFORMS=${PLATFORMS_INPUT}" >> "$GITHUB_ENV"
+          echo "PUBLISH_LATEST=${PUBLISH_LATEST_INPUT}" >> "$GITHUB_ENV"
 
-          if [ -n "${{ github.event.inputs.image_name }}" ]; then
-            echo "IMAGE_NAME=${{ github.event.inputs.image_name }}" >> $GITHUB_ENV
+          if [ -n "$IMAGE_NAME_INPUT" ]; then
+            IMAGE_NAME="${IMAGE_NAME_INPUT}"
           else
-            OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-            echo "IMAGE_NAME=ghcr.io/${OWNER}/yaffa" >> $GITHUB_ENV
+            OWNER=$(printf '%s' "$REPO_OWNER_INPUT" | tr '[:upper:]' '[:lower:]')
+            IMAGE_NAME="ghcr.io/${OWNER}/yaffa"
           fi
+
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
+
+          IMAGE_TAGS="${IMAGE_NAME}:${DOCKER_VERSION_TAG}"
+          if [ "$PUBLISH_LATEST_INPUT" = "true" ]; then
+            IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_NAME}:latest"
+          fi
+          echo "IMAGE_TAGS=${IMAGE_TAGS}" >> "$GITHUB_ENV"
 
       - name: Print build info
         run: |
@@ -74,9 +91,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-${{ github.ref_name }}-${{ github.sha }}
+          key: buildx-${{ env.SOURCE_BRANCH_SAFE }}-${{ github.sha }}
           restore-keys: |
-            buildx-${{ github.ref_name }}-
+            buildx-${{ env.SOURCE_BRANCH_SAFE }}-
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -85,9 +102,7 @@ jobs:
           file: ./docker/Dockerfile
           platforms: ${{ env.BUILD_PLATFORMS }}
           push: true
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.DOCKER_VERSION_TAG }}
-            ${{ env.PUBLISH_LATEST == 'true' && format('{0}:latest', env.IMAGE_NAME) || '' }}
+          tags: ${{ env.IMAGE_TAGS }}
           build-args: |
             BRANCH=${{ env.SOURCE_BRANCH }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
**Description**  
This change adds a separate, manual Docker build workflow for contributors without modifying the existing release-oriented `docker-build.yml`.

**What was added**
- New workflow: `.github/workflows/docker-build-contributor.yml`
- Trigger: `workflow_dispatch` only
- Inputs:
  - `source_branch` (branch to build)
  - `platforms` (comma-separated platforms)
  - `image_name` (optional custom image target)
  - `publish_latest` (`true/false`)

**Behavior**
- Checks out the selected branch (`source_branch`)
- Builds a timestamped tag: `<sanitized-branch>-<YYYYMMDD-HHMM>`
- Pushes image to GHCR
- Optionally also publishes `:latest` when `publish_latest=true`
- Uses build cache (`actions/cache`) like the main workflow
- Passes `BRANCH=<source_branch>` as Docker build-arg

**Why**
- Keeps the default release pipeline unchanged
- Gives contributors an isolated, opt-in way to build/publish test images
- Minimizes merge risk by introducing a new workflow file instead of editing existing production CI

**Impact**
- Non-invasive: no changes to current release automation
- Flexible for contributor testing and branch-specific images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a contributor-triggered CI workflow to optionally build and publish Docker images. Supports multi-platform builds, configurable inputs (branch, platforms, image name, publish-latest option), computed image tagging including optional "latest", and local build caching to speed repeated builds. Logs resolved parameters and pushes built images when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->