### PR TITLE
fix: correct transaction type comparisons in ResultsCard after v3 enum migration

### DIFF
--- a/resources/js/investments/components/display/ResultsCard.vue
+++ b/resources/js/investments/components/display/ResultsCard.vue
@@ -116,6 +116,7 @@
 <script>
   import { toFormattedCurrency, __ } from '@/shared/lib/i18n';
   import * as toastHelpers from '@/shared/lib/toast';
+  import { getTransactionTypeConfig } from '@/shared/lib/helpers';
 
   export default {
     name: 'ResultsCard',
@@ -272,7 +273,7 @@
           getSum(
             arr,
             (trx) =>
-              (trx.transaction_type.quantity_multiplier || 0) *
+              (getTransactionTypeConfig(trx.transaction_type).quantity_multiplier || 0) *
               (trx.config.quantity || 0),
           );
         let lastPrice = 1;
@@ -286,10 +287,10 @@
         }
         const quantity = getQtyMult(filtered);
         const value = quantity * lastPrice;
-        const buying = getVal(filtered, 'Buy');
-        const selling = getVal(filtered, 'Sell');
-        const added = getQty(filtered, 'Add');
-        const removed = getQty(filtered, 'Remove');
+        const buying = getVal(filtered, 'buy');
+        const selling = getVal(filtered, 'sell');
+        const added = getQty(filtered, 'add_shares');
+        const removed = getQty(filtered, 'remove_shares');
         const dividend = getField(filtered, 'dividend');
         const commission = getField(filtered, 'commission');
         const taxes = getField(filtered, 'tax');


### PR DESCRIPTION
## Summary

- `transaction_type` in v3 is a lowercase string enum value (`'buy'`, `'sell'`, `'add_shares'`, `'remove_shares'`) instead of a PHP-backed enum object
- `ResultsCard.vue` was comparing against capitalized strings (`'Buy'`, `'Sell'`, `'Add'`, `'Remove'`) — no longer matching, so Buying cost, Selling revenue, Quantity and Value always showed 0
- `trx.transaction_type.quantity_multiplier` was accessing a property on a plain string (always `undefined`), also zeroing out Quantity

## Changes

- Import `getTransactionTypeConfig` from `@/shared/lib/helpers` (already used elsewhere in the codebase) to look up `quantity_multiplier` from the transaction type string
- Update string literals to match v3 enum values: `'buy'`, `'sell'`, `'add_shares'`, `'remove_shares'`

## Test plan

- [ ] Open an investment with buy/sell transactions
- [ ] Verify Buying cost, Selling revenue, Quantity and Value show correct non-zero values
- [ ] Verify Result and ROI are calculated correctly
- [ ] Verify Add/Remove shares quantities are counted correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction type identification in investment results calculations; transaction type values now correctly match expected identifiers.

* **Refactor**
  * Improved quantity multiplier computation to use centralized helper function for consistent transaction type configuration retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->