### PR TITLE
Add configurable decimal precision for currency display

### DIFF
--- a/app/Http/Requests/CurrencyRequest.php
+++ b/app/Http/Requests/CurrencyRequest.php
@@ -42,11 +42,13 @@ class CurrencyRequest extends FormRequest
                 'nullable',
                 'integer',
                 'min:0',
+                'max:100',
             ],
             'detailed_decimal_precision' => [
                 'nullable',
                 'integer',
                 'min:0',
+                'max:100',
             ],
         ];
     }

--- a/app/Http/Requests/CurrencyRequest.php
+++ b/app/Http/Requests/CurrencyRequest.php
@@ -38,6 +38,16 @@ class CurrencyRequest extends FormRequest
             'auto_update' => [
                 'boolean',
             ],
+            'generic_decimal_precision' => [
+                'nullable',
+                'integer',
+                'min:0',
+            ],
+            'detailed_decimal_precision' => [
+                'nullable',
+                'integer',
+                'min:0',
+            ],
         ];
     }
 

--- a/app/Models/Currency.php
+++ b/app/Models/Currency.php
@@ -27,6 +27,8 @@ use Kantorge\CurrencyExchangeRates\Facades\CurrencyExchangeRates;
  * @property string $iso_code
  * @property bool|null $base
  * @property bool $auto_update
+ * @property int|null $generic_decimal_precision
+ * @property int|null $detailed_decimal_precision
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read User $user
@@ -65,6 +67,8 @@ class Currency extends Model
         'iso_code',
         'base',
         'auto_update',
+        'generic_decimal_precision',
+        'detailed_decimal_precision',
     ];
 
     /**
@@ -77,6 +81,8 @@ class Currency extends Model
         return [
             'base' => 'boolean',
             'auto_update' => 'boolean',
+            'generic_decimal_precision' => 'integer',
+            'detailed_decimal_precision' => 'integer',
         ];
     }
 

--- a/database/migrations/2026_04_14_000001_add_decimal_precision_to_currencies_table.php
+++ b/database/migrations/2026_04_14_000001_add_decimal_precision_to_currencies_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('currencies', function (Blueprint $table) {
+            $table->unsignedInteger('generic_decimal_precision')->nullable()->after('auto_update');
+            $table->unsignedInteger('detailed_decimal_precision')->nullable()->after('generic_decimal_precision');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('currencies', function (Blueprint $table) {
+            $table->dropColumn(['generic_decimal_precision', 'detailed_decimal_precision']);
+        });
+    }
+};

--- a/resources/js/currencies/index.js
+++ b/resources/js/currencies/index.js
@@ -63,11 +63,9 @@ $(dataTableSelector).DataTable({
                     return row.latest_rate;
                 }
                 // Formatted text is returned for display in a specific way
-                const targetCurrency = Object.assign({}, window.YAFFA.userSettings.baseCurrency, {max_digits: 4});
-
-                return toFormattedCurrency(1, window.YAFFA.userSettings.locale, row) +
+                return toFormattedCurrency(1, window.YAFFA.userSettings.locale, row, 'detailed') +
                     " = " +
-                    toFormattedCurrency(parseFloat(row.latest_rate), window.YAFFA.userSettings.locale, targetCurrency);
+                    toFormattedCurrency(parseFloat(row.latest_rate), window.YAFFA.userSettings.locale, window.YAFFA.userSettings.baseCurrency, 'detailed');
             },
             className: "dt-nowrap",
             searchable: false,
@@ -89,11 +87,9 @@ $(dataTableSelector).DataTable({
                     return 1 / row.latest_rate;
                 }
                 // Formatted text is returned for display in a specific way
-                const targetCurrency = Object.assign({}, row, {max_digits: 4});
-
-                return toFormattedCurrency(1, window.YAFFA.userSettings.locale, window.YAFFA.userSettings.baseCurrency) +
+                return toFormattedCurrency(1, window.YAFFA.userSettings.locale, window.YAFFA.userSettings.baseCurrency, 'detailed') +
                     " = " +
-                    toFormattedCurrency((1 / parseFloat(row.latest_rate)), window.YAFFA.userSettings.locale, targetCurrency);
+                    toFormattedCurrency((1 / parseFloat(row.latest_rate)), window.YAFFA.userSettings.locale, row, 'detailed');
             },
             className: "dt-nowrap",
             searchable: false,

--- a/resources/js/currency-rates/components/CurrencyRateOverview.vue
+++ b/resources/js/currency-rates/components/CurrencyRateOverview.vue
@@ -34,13 +34,14 @@
         </dd>
         <dt class="col-6">{{ __('Last known rate') }}</dt>
         <dd class="col-6" v-if="currencyRates.length > 0">
-          {{ toFormattedCurrency(1, locale, from) }}
+          {{ toFormattedCurrency(1, locale, from, 'detailed') }}
           =
           {{
             toFormattedCurrency(
               currencyRates[currencyRates.length - 1].rate,
               locale,
               to,
+              'detailed',
             )
           }}
         </dd>

--- a/resources/js/currency-rates/components/CurrencyRateTable.vue
+++ b/resources/js/currency-rates/components/CurrencyRateTable.vue
@@ -91,7 +91,8 @@
                   type,
                   data,
                   window.YAFFA.userSettings.locale,
-                  Object.assign({}, self.toCurrency, { max_digits: 4 }),
+                  self.toCurrency,
+                  'detailed',
                 );
               },
             },

--- a/resources/js/investment-price/components/InvestmentPriceOverview.vue
+++ b/resources/js/investment-price/components/InvestmentPriceOverview.vue
@@ -36,9 +36,8 @@
             toFormattedCurrency(
               investmentPrices[investmentPrices.length - 1].price,
               locale,
-              {
-                iso_code: investment.currency.iso_code,
-              },
+              investment.currency,
+              'detailed',
             )
           }}
         </dd>

--- a/resources/js/investment-price/components/InvestmentPriceOverviewCard.vue
+++ b/resources/js/investment-price/components/InvestmentPriceOverviewCard.vue
@@ -34,13 +34,14 @@
         </dd>
         <dt class="col-6">{{ __('Last known rate') }}</dt>
         <dd class="col-6" v-if="currencyRates.length > 0">
-          {{ toFormattedCurrency(1, locale, from) }}
+          {{ toFormattedCurrency(1, locale, from, 'detailed') }}
           =
           {{
             toFormattedCurrency(
               currencyRates[currencyRates.length - 1].rate,
               locale,
               to,
+              'detailed',
             )
           }}
         </dd>
@@ -72,9 +73,7 @@
 
         return date.toLocaleDateString(this.locale);
       },
-      toFormattedCurrency(value, locale, currency) {
-        return toFormattedCurrency(value, locale, currency);
-      },
+      toFormattedCurrency,
       __,
     },
   };

--- a/resources/js/investment-price/components/InvestmentPriceTable.vue
+++ b/resources/js/investment-price/components/InvestmentPriceTable.vue
@@ -88,9 +88,8 @@
                   type,
                   data,
                   window.YAFFA.userSettings.locale,
-                  {
-                    iso_code: self.investment.currency.iso_code,
-                  },
+                  self.investment.currency,
+                  'detailed',
                 );
               },
             },

--- a/resources/js/investments/components/display/CurrentAssetsCard.vue
+++ b/resources/js/investments/components/display/CurrentAssetsCard.vue
@@ -16,6 +16,7 @@
               investment.latest_price,
               locale,
               investment.currency,
+              'detailed',
             )
           }}
         </dd>

--- a/resources/js/investments/components/display/TransactionHistoryCard.vue
+++ b/resources/js/investments/components/display/TransactionHistoryCard.vue
@@ -244,6 +244,7 @@
                 data,
                 vm.locale,
                 vm.investment.currency,
+                'detailed',
               );
             },
           },

--- a/resources/js/investments/index.js
+++ b/resources/js/investments/index.js
@@ -71,7 +71,7 @@ let table = $('#investmentSummary').DataTable({
             title: __("Latest price"),
             render: function (data, type, row) {
                 if (type === 'display' && !isNaN(data) && typeof data === "number") {
-                    return toFormattedCurrency(data, window.YAFFA.userSettings.locale, row.currency);
+                    return toFormattedCurrency(data, window.YAFFA.userSettings.locale, row.currency, 'detailed');
                 }
 
                 return data;

--- a/resources/js/shared/lib/datatable/index.js
+++ b/resources/js/shared/lib/datatable/index.js
@@ -159,9 +159,10 @@ export function commentIcon(comment, type) {
  * @param {number} input
  * @param {string} locale
  * @param {Object} currency
+ * @param {'generic'|'detailed'} [precision='generic']
  * @returns {number|string}
  */
-export function toFormattedCurrency(type, input, locale, currency) {
+export function toFormattedCurrency(type, input, locale, currency, precision = 'generic') {
     if (type === 'filter' || type === 'sort') {
         return input;
     }
@@ -170,7 +171,7 @@ export function toFormattedCurrency(type, input, locale, currency) {
         return input;
     }
 
-    return toFormattedCurrencyHelper(input, locale, currency);
+    return toFormattedCurrencyHelper(input, locale, currency, precision);
 }
 
 export function initializeSkipInstanceButton(selector) {

--- a/resources/js/shared/lib/helpers/index.js
+++ b/resources/js/shared/lib/helpers/index.js
@@ -1,40 +1,4 @@
 /**
- * @param {number} input The number to be formatted as currency.
- * @param {string} locale The locale to be used for formatting.
- * @param {Object} currencySettings Object with settings to apply. Expected key(s): iso_code. Optional key(s): min_digits, max_digits.
- * @property {string} currencySettings.iso_code
- * @property {number} currencySettings.min_digits
- * @property {number} currencySettings.max_digits
- *
- * @type {string}
- */
-export function toFormattedCurrency(input, locale, currencySettings) {
-    // Fallback to raw input if currency settings are missing
-    if (!currencySettings || !currencySettings.iso_code) {
-        return input.toString();
-    }
-
-    // If input is not a number, return it as is
-    if (input === null || input === undefined) {
-        return '';
-    }
-    if (isNaN(input)) {
-        return input.toString();
-    }
-
-    return input.toLocaleString(
-        locale,
-        {
-            style: 'currency',
-            currency: currencySettings.iso_code,
-            currencyDisplay: 'narrowSymbol',
-            minimumFractionDigits: currencySettings.min_digits || 0,
-            maximumFractionDigits: currencySettings.max_digits
-        }
-    );
-}
-
-/**
  * Helper function to get transaction type configuration from window.YAFFA.config.transactionTypes
  * @param {string} transactionTypeValue - The enum value (e.g., 'buy', 'sell', 'withdrawal')
  * @returns {object} Transaction type configuration with category, label, multipliers, etc.
@@ -48,24 +12,6 @@ export function getTransactionTypeConfig(transactionTypeValue) {
         amount_multiplier: null,
         quantity_multiplier: null,
     };
-}
-
-/**
- * Gets the currency symbol for a given locale and ISO currency code.
- *
- * @param {string} locale - The locale string (e.g., 'en-US', 'de-DE')
- * @param {string} iso_code - The ISO 4217 currency code (e.g., 'USD', 'EUR')
- *
- * @returns {string} The currency symbol for the specified locale and currency
- */
-export function getCurrencySymbol(locale, iso_code) {
-    const numberFormat = new Intl.NumberFormat(locale, {
-        style: 'currency',
-        currency: iso_code,
-        currencyDisplay: 'narrowSymbol',
-    });
-    const symbol = numberFormat.format(0).match(/[^0-9,.\s]+/);
-    return symbol[0];
 }
 
 /**

--- a/resources/js/shared/lib/i18n/format.js
+++ b/resources/js/shared/lib/i18n/format.js
@@ -26,7 +26,8 @@ export function toFormattedCurrency(input, locale, currencySettings, precision =
     }
 
     let minDigits = currencySettings.min_digits || 0;
-    let maxDigits = currencySettings.max_digits;
+    // Allow maxDigits to be 0 if explicitly set, otherwise default to undefined to prevent issues with potential null values
+    let maxDigits = currencySettings.max_digits ?? undefined;
 
     if (precision === 'generic' && currencySettings.generic_decimal_precision != null) {
         minDigits = currencySettings.generic_decimal_precision;

--- a/resources/js/shared/lib/i18n/format.js
+++ b/resources/js/shared/lib/i18n/format.js
@@ -1,14 +1,17 @@
 /**
  * @param {number} input The number to be formatted as currency.
  * @param {string} locale The locale to be used for formatting.
- * @param {Object} currencySettings Object with settings to apply. Expected key(s): iso_code. Optional key(s): min_digits, max_digits.
+ * @param {Object} currencySettings Object with settings to apply. Expected key(s): iso_code. Optional key(s): min_digits, max_digits, generic_decimal_precision, detailed_decimal_precision.
  * @property {string} currencySettings.iso_code
  * @property {number} currencySettings.min_digits
  * @property {number} currencySettings.max_digits
+ * @property {number|null} currencySettings.generic_decimal_precision
+ * @property {number|null} currencySettings.detailed_decimal_precision
+ * @param {'generic'|'detailed'} [precision='generic'] Whether to apply generic or detailed decimal precision from the currency settings.
  *
  * @type {string}
  */
-export function toFormattedCurrency(input, locale, currencySettings) {
+export function toFormattedCurrency(input, locale, currencySettings, precision = 'generic') {
     // Fallback to raw input if currency settings are missing
     if (!currencySettings || !currencySettings.iso_code) {
         return input.toString();
@@ -22,14 +25,25 @@ export function toFormattedCurrency(input, locale, currencySettings) {
         return input.toString();
     }
 
+    let minDigits = currencySettings.min_digits || 0;
+    let maxDigits = currencySettings.max_digits;
+
+    if (precision === 'generic' && currencySettings.generic_decimal_precision != null) {
+        minDigits = currencySettings.generic_decimal_precision;
+        maxDigits = currencySettings.generic_decimal_precision;
+    } else if (precision === 'detailed' && currencySettings.detailed_decimal_precision != null) {
+        minDigits = currencySettings.detailed_decimal_precision;
+        maxDigits = currencySettings.detailed_decimal_precision;
+    }
+
     return input.toLocaleString(
         locale,
         {
             style: 'currency',
             currency: currencySettings.iso_code,
             currencyDisplay: 'narrowSymbol',
-            minimumFractionDigits: currencySettings.min_digits || 0,
-            maximumFractionDigits: currencySettings.max_digits
+            minimumFractionDigits: minDigits,
+            maximumFractionDigits: maxDigits,
         }
     );
 }

--- a/resources/views/currencies/form.blade.php
+++ b/resources/views/currencies/form.blade.php
@@ -95,6 +95,7 @@
                         name="generic_decimal_precision"
                         type="number"
                         min="0"
+                        max="100"
                         value="{{ old('generic_decimal_precision', $currency->generic_decimal_precision ?? '') }}"
                     >
                 </div>
@@ -111,6 +112,7 @@
                         name="detailed_decimal_precision"
                         type="number"
                         min="0"
+                        max="100"
                         value="{{ old('detailed_decimal_precision', $currency->detailed_decimal_precision ?? '') }}"
                     >
                 </div>

--- a/resources/views/currencies/form.blade.php
+++ b/resources/views/currencies/form.blade.php
@@ -83,6 +83,38 @@
                     >
                 </div>
             </div>
+
+            <div class="row mb-3">
+                <label for="generic_decimal_precision" class="col-form-label col-sm-3">
+                    {{ __('Generic decimal precision') }}
+                </label>
+                <div class="col-sm-9">
+                    <input
+                        class="form-control"
+                        id="generic_decimal_precision"
+                        name="generic_decimal_precision"
+                        type="number"
+                        min="0"
+                        value="{{ old('generic_decimal_precision', $currency->generic_decimal_precision ?? '') }}"
+                    >
+                </div>
+            </div>
+
+            <div class="row mb-3">
+                <label for="detailed_decimal_precision" class="col-form-label col-sm-3">
+                    {{ __('Detailed decimal precision') }}
+                </label>
+                <div class="col-sm-9">
+                    <input
+                        class="form-control"
+                        id="detailed_decimal_precision"
+                        name="detailed_decimal_precision"
+                        type="number"
+                        min="0"
+                        value="{{ old('detailed_decimal_precision', $currency->detailed_decimal_precision ?? '') }}"
+                    >
+                </div>
+            </div>
         </div>
         <div class="card-footer">
             @csrf


### PR DESCRIPTION
### Motivation

Improves the flexibility and accuracy of currency value representation by allowing users to customize the number of decimal places shown for each currency.

### Key Changes

- Introduces two new configurable fields for currencies: generic and detailed decimal precision.
- Updates backend validation, models, and database schema to support storing these precision settings.
- Enhances currency formatting logic to apply the configured decimal precision dynamically in both generic and detailed display modes.
- Updates the user interface to allow input of these precision values when managing currencies.
- Refactors frontend currency display to consistently leverage the selected precision for improved clarity and consistency.

### Benefits

- Enables users to tailor currency displays to meet regional or domain-specific accuracy requirements.
- Reduces visual clutter or rounding errors in financial data presentation.
- Lays groundwork for more robust internationalization and user preference support.

closes #451 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generic and detailed decimal precision settings for currencies, allowing customized formatting of currency values across the application.
  * New form fields enable configuration of precision levels for currency display in both generic and detailed contexts.

* **Improvements**
  * Updated currency formatting throughout the application to support precision-based display modes for improved clarity in financial data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->