### PR TITLE
feat: adds generic API investment price provider

### DIFF
--- a/.ai/docs/features/investment-price-providers/generic-api-provider-configuration.md
+++ b/.ai/docs/features/investment-price-providers/generic-api-provider-configuration.md
@@ -1,0 +1,254 @@
+# Generic API Provider Configuration
+
+## Summary
+
+The `generic_api` provider lets a user define how prices are fetched from any JSON HTTP API.
+
+This document covers:
+
+- API endpoints used to save and validate provider configuration
+- all supported configuration fields
+- sample request/response payloads
+- both parsing modes:
+  - object-item mode (single `items_path` collection)
+  - parallel-array mode (separate date and price arrays)
+
+All examples below use sample endpoints and sample payloads.
+
+## Backend Endpoints
+
+The following endpoints are used for provider-level configuration:
+
+- `PATCH /api/v1/investment-provider-configs/generic_api`
+  - Create or update the authenticated user's `generic_api` configuration.
+- `POST /api/v1/investment-provider-configs/generic_api/test`
+  - Validate credentials/configuration for `generic_api`.
+- `GET /api/v1/investment-provider-configs/generic_api`
+  - Read current saved configuration metadata (credentials are not returned).
+
+Optional runtime test endpoint (investment form test action):
+
+- `POST /api/v1/investment-price-providers/generic_api/test-fetch`
+  - Runs a provider fetch using a symbol and provider settings.
+
+## Configuration Fields (credentials)
+
+`credentials` is a JSON object stored encrypted at rest.
+
+- `endpoint_url` (string, required)
+  - URL for the upstream API request.
+  - Placeholders supported: `{symbol}`, `{from}`, `{to}`.
+- `http_method` (string, optional)
+  - Allowed: `GET`, `POST`.
+  - Default: `GET`.
+- `headers_json` (string, optional)
+  - JSON object string for request headers.
+- `query_json` (string, optional)
+  - JSON object string for query parameters.
+- `body_json` (string, optional)
+  - JSON object string for POST body.
+- `date_format` (string, optional)
+  - Allowed: `auto`, `Y-m-d`, `timestamp_seconds`, `timestamp_milliseconds`.
+  - Default: `auto`.
+
+Object-item mode fields:
+
+- `items_path` (string, optional)
+  - Path to array of objects. If empty, full response is treated as one item.
+- `date_path` (string, conditionally required)
+  - Path to date value inside each item object.
+- `price_path` (string, conditionally required)
+  - Path to price value inside each item object.
+
+Parallel-array mode fields:
+
+- `date_values_path` (string, conditionally required)
+  - Path to date array.
+- `price_values_path` (string, conditionally required)
+  - Path to price array.
+
+Conditional validation behavior:
+
+- If either `date_values_path` or `price_values_path` is present, parallel-array mode is active and both are required.
+- If parallel-array mode is not active, `date_path` and `price_path` are required.
+
+## Placeholder Rules
+
+Placeholders are interpolated in:
+
+- `endpoint_url`
+- `headers_json`
+- `query_json`
+- `body_json`
+
+Supported tokens:
+
+- `{symbol}`: investment symbol, for example `MSFT`
+- `{from}`: start date in `Y-m-d`
+- `{to}`: current date in `Y-m-d`
+
+## Example A: Object-Item Mode
+
+### Sample upstream endpoint
+
+`GET https://prices.sample-api.dev/v1/eod?ticker={symbol}`
+
+### Sample upstream JSON response
+
+```json
+{
+  "data": [
+    { "d": "2026-05-28", "close": 410.12 },
+    { "d": "2026-05-29", "close": 411.78 },
+    { "d": "2026-05-30", "close": 409.55 }
+  ]
+}
+```
+
+### Save config request
+
+```http
+PATCH /api/v1/investment-provider-configs/generic_api
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "credentials": {
+    "endpoint_url": "https://prices.sample-api.dev/v1/eod",
+    "http_method": "GET",
+    "query_json": "{\"ticker\":\"{symbol}\"}",
+    "items_path": "data",
+    "date_path": "d",
+    "price_path": "close",
+    "date_format": "Y-m-d"
+  }
+}
+```
+
+### Save config response (example)
+
+```json
+{
+  "id": 12,
+  "provider_key": "generic_api",
+  "options": null,
+  "last_error": null,
+  "rate_limit_overrides": null,
+  "has_credentials": true,
+  "created_at": "2026-06-07T12:10:12.000000Z",
+  "updated_at": "2026-06-07T12:10:12.000000Z"
+}
+```
+
+## Example B: Parallel-Array Mode
+
+### Sample upstream endpoint
+
+`GET https://market-data.sample-api.dev/history/{symbol}`
+
+### Sample upstream JSON response
+
+```json
+{
+  "history": {
+    "dates": [1717718400, 1717804800, 1717891200],
+    "last": [99.5, 101.2, 100.75]
+  }
+}
+```
+
+### Save config request
+
+```http
+PATCH /api/v1/investment-provider-configs/generic_api
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "credentials": {
+    "endpoint_url": "https://market-data.sample-api.dev/history/{symbol}",
+    "http_method": "GET",
+    "date_values_path": "history.dates",
+    "price_values_path": "history.last",
+    "date_format": "timestamp_seconds"
+  }
+}
+```
+
+Notes:
+
+- In parallel mode, `date_path` and `price_path` are not required.
+- The parser zips arrays by index and skips rows where date or price is missing/invalid.
+
+## Testing Configuration
+
+### Validate credentials/config fields
+
+```http
+POST /api/v1/investment-provider-configs/generic_api/test
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "credentials": {
+    "endpoint_url": "https://market-data.sample-api.dev/history/{symbol}",
+    "http_method": "GET",
+    "date_values_path": "history.dates",
+    "price_values_path": "history.last",
+    "date_format": "timestamp_seconds"
+  }
+}
+```
+
+Success response:
+
+```json
+{
+  "message": "Provider configuration is valid."
+}
+```
+
+Validation error example:
+
+```json
+{
+  "message": "The given data was invalid.",
+  "errors": {
+    "credentials.price_values_path": [
+      "This field is required when using parallel array mode."
+    ]
+  }
+}
+```
+
+### Runtime fetch test
+
+```http
+POST /api/v1/investment-price-providers/generic_api/test-fetch
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "symbol": "MSFT",
+  "provider_settings": {}
+}
+```
+
+Success response (example):
+
+```json
+{
+  "message": "Test fetch successful.",
+  "provider_key": "generic_api",
+  "symbol": "MSFT",
+  "price": 101.2,
+  "date": "2024-06-08"
+}
+```
+
+## Operational Notes
+
+- Credentials are encrypted at rest and never returned by API responses.
+- Empty string values are treated as missing for required checks.
+- In `auto` date mode, numeric dates are treated as unix timestamps; very large values are interpreted as milliseconds.
+- Only positive numeric prices are accepted.

--- a/app/Http/Requests/InvestmentProviderConfigRequest.php
+++ b/app/Http/Requests/InvestmentProviderConfigRequest.php
@@ -7,6 +7,7 @@ use App\Services\InvestmentPriceProviderRegistry;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Closure;
 
 class InvestmentProviderConfigRequest extends FormRequest
 {
@@ -58,7 +59,26 @@ class InvestmentProviderConfigRequest extends FormRequest
             }
 
             if (($fieldSchema['format'] ?? null) === 'url') {
-                $fieldRules[] = 'url';
+                if (($fieldSchema['allowPlaceholders'] ?? false) === true) {
+                    $fieldRules[] = function (string $attribute, mixed $value, Closure $fail): void {
+                        if (! is_string($value)) {
+                            return;
+                        }
+
+                        // Apply simple placeholder replacements to validate the URL format
+                        $resolved = strtr($value, [
+                            '{symbol}' => 'AAPL',
+                            '{from}' => '2024-01-01',
+                            '{to}' => '2024-01-02',
+                        ]);
+
+                        if (! filter_var($resolved, FILTER_VALIDATE_URL)) {
+                            $fail(__('The :attribute field must contain a valid URL.', ['attribute' => $attribute]));
+                        }
+                    };
+                } else {
+                    $fieldRules[] = 'url';
+                }
             }
 
             if (isset($fieldSchema['enum']) && is_array($fieldSchema['enum'])) {
@@ -116,7 +136,64 @@ class InvestmentProviderConfigRequest extends FormRequest
             }
 
             $this->validateRateLimitOverrides($validator, $metadata, $existingConfig);
+            $this->validateGenericApiConditionalRequirements($validator, $providerKey, $existingConfig);
         });
+    }
+
+    private function validateGenericApiConditionalRequirements(
+        Validator $validator,
+        string $providerKey,
+        ?InvestmentProviderConfig $existingConfig
+    ): void {
+        if ($providerKey !== 'generic_api') {
+            return;
+        }
+
+        $credentials = $this->input('credentials', []);
+        if (! is_array($credentials)) {
+            $credentials = [];
+        }
+
+        $storedCredentials = is_array($existingConfig?->credentials)
+            ? $existingConfig->credentials
+            : [];
+
+        $effectiveCredentials = array_merge($storedCredentials, $credentials);
+
+        $datePath = isset($effectiveCredentials['date_path']) && is_string($effectiveCredentials['date_path'])
+            ? mb_trim($effectiveCredentials['date_path'])
+            : '';
+        $pricePath = isset($effectiveCredentials['price_path']) && is_string($effectiveCredentials['price_path'])
+            ? mb_trim($effectiveCredentials['price_path'])
+            : '';
+        $dateValuesPath = isset($effectiveCredentials['date_values_path']) && is_string($effectiveCredentials['date_values_path'])
+            ? mb_trim($effectiveCredentials['date_values_path'])
+            : '';
+        $priceValuesPath = isset($effectiveCredentials['price_values_path']) && is_string($effectiveCredentials['price_values_path'])
+            ? mb_trim($effectiveCredentials['price_values_path'])
+            : '';
+
+        $parallelModeEnabled = $dateValuesPath !== '' || $priceValuesPath !== '';
+
+        if ($parallelModeEnabled) {
+            if ($dateValuesPath === '') {
+                $validator->errors()->add('credentials.date_values_path', __('This field is required when using parallel array mode.'));
+            }
+
+            if ($priceValuesPath === '') {
+                $validator->errors()->add('credentials.price_values_path', __('This field is required when using parallel array mode.'));
+            }
+
+            return;
+        }
+
+        if ($datePath === '') {
+            $validator->errors()->add('credentials.date_path', __('This field is required unless parallel array mode is used.'));
+        }
+
+        if ($pricePath === '') {
+            $validator->errors()->add('credentials.price_path', __('This field is required unless parallel array mode is used.'));
+        }
     }
 
     private function validateRateLimitOverrides(

--- a/app/Providers/InvestmentPriceProviderServiceProvider.php
+++ b/app/Providers/InvestmentPriceProviderServiceProvider.php
@@ -37,7 +37,12 @@ class InvestmentPriceProviderServiceProvider extends ServiceProvider implements 
             // Register Generic API provider (advanced, user-configured)
             $registry->register(
                 'generic_api',
-                new GenericApiProvider(new Client())
+                new GenericApiProvider(new Client([
+                    'timeout' => 30,
+                    'connect_timeout' => 10,
+                    'verify' => true,
+                    'http_errors' => true,
+                ]))
             );
 
             return $registry;

--- a/app/Providers/InvestmentPriceProviderServiceProvider.php
+++ b/app/Providers/InvestmentPriceProviderServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Services\InvestmentPriceProviderRegistry;
 use App\Services\InvestmentPriceProviders\AlphaVantageProvider;
+use App\Services\InvestmentPriceProviders\GenericApiProvider;
 use App\Services\InvestmentPriceProviders\WebScrapingProvider;
 use App\Services\ScraperService;
 use GuzzleHttp\Client;
@@ -31,6 +32,12 @@ class InvestmentPriceProviderServiceProvider extends ServiceProvider implements 
             $registry->register(
                 'web_scraping',
                 new WebScrapingProvider(new ScraperService())
+            );
+
+            // Register Generic API provider (advanced, user-configured)
+            $registry->register(
+                'generic_api',
+                new GenericApiProvider(new Client())
             );
 
             return $registry;

--- a/app/Services/InvestmentPriceProviders/GenericApiProvider.php
+++ b/app/Services/InvestmentPriceProviders/GenericApiProvider.php
@@ -9,6 +9,7 @@ use App\Models\Investment;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Str;
 use JsonException;
 use Throwable;
 
@@ -44,6 +45,7 @@ class GenericApiProvider implements InvestmentPriceProvider
         ];
 
         $resolvedEndpointUrl = $this->interpolate((string) $endpointUrl, $placeholders);
+        $this->assertPublicEndpointUrl($resolvedEndpointUrl, $investment->symbol);
 
         $headers = $this->parseJsonObjectCredential($credentials, 'headers_json', $placeholders, $investment);
         $query = $this->parseJsonObjectCredential($credentials, 'query_json', $placeholders, $investment);
@@ -73,14 +75,14 @@ class GenericApiProvider implements InvestmentPriceProvider
 
             $prices = [];
             $dateFormat = isset($credentials['date_format']) && is_string($credentials['date_format'])
-                ? mb_trim($credentials['date_format'])
+                ? Str::trim($credentials['date_format'])
                 : 'auto';
 
             $dateValuesPath = isset($credentials['date_values_path']) && is_string($credentials['date_values_path'])
-                ? mb_trim($credentials['date_values_path'])
+                ? Str::trim($credentials['date_values_path'])
                 : '';
             $priceValuesPath = isset($credentials['price_values_path']) && is_string($credentials['price_values_path'])
-                ? mb_trim($credentials['price_values_path'])
+                ? Str::trim($credentials['price_values_path'])
                 : '';
 
             if ($dateValuesPath !== '' || $priceValuesPath !== '') {
@@ -95,39 +97,34 @@ class GenericApiProvider implements InvestmentPriceProvider
                     );
                 }
 
+                $dateValues = array_values($dateValues);
+                $priceValues = array_values($priceValues);
+
                 foreach ($dateValues as $index => $rawDate) {
                     $rawPrice = $priceValues[$index] ?? null;
 
-                    if ($rawDate === null || $rawPrice === null || ! is_numeric($rawPrice)) {
-                        continue;
+                    $normalizedPrice = $this->normalizeDatePrice(
+                        $rawDate,
+                        $rawPrice,
+                        $dateFormat,
+                        $cutoff,
+                        $investment,
+                    );
+
+                    if ($normalizedPrice !== null) {
+                        $prices[] = $normalizedPrice;
                     }
-
-                    $day = $this->parseDate($rawDate, $dateFormat, $investment);
-
-                    if ($cutoff !== null && $day->lt($cutoff)) {
-                        continue;
-                    }
-
-                    $price = (float) $rawPrice;
-                    if ($price <= 0) {
-                        continue;
-                    }
-
-                    $prices[] = [
-                        'date' => $day->format('Y-m-d'),
-                        'price' => $price,
-                    ];
                 }
             } else {
                 $datePath = $this->requiredStringCredential($credentials, 'date_path', $investment);
                 $pricePath = $this->requiredStringCredential($credentials, 'price_path', $investment);
 
                 $itemsPath = isset($credentials['items_path']) && is_string($credentials['items_path'])
-                    ? mb_trim($credentials['items_path'])
+                    ? Str::trim($credentials['items_path'])
                     : '';
 
                 $items = $itemsPath === ''
-                    ? [$decodedBody]
+                    ? (isset($decodedBody[0]) && is_array($decodedBody[0]) ? $decodedBody : [$decodedBody])
                     : data_get($decodedBody, $itemsPath);
 
                 if (! is_array($items) || $items === []) {
@@ -146,25 +143,17 @@ class GenericApiProvider implements InvestmentPriceProvider
                     $rawDate = data_get($item, $datePath);
                     $rawPrice = data_get($item, $pricePath);
 
-                    if ($rawDate === null || $rawPrice === null || ! is_numeric($rawPrice)) {
-                        continue;
+                    $normalizedPrice = $this->normalizeDatePrice(
+                        $rawDate,
+                        $rawPrice,
+                        $dateFormat,
+                        $cutoff,
+                        $investment,
+                    );
+
+                    if ($normalizedPrice !== null) {
+                        $prices[] = $normalizedPrice;
                     }
-
-                    $day = $this->parseDate($rawDate, $dateFormat, $investment);
-
-                    if ($cutoff !== null && $day->lt($cutoff)) {
-                        continue;
-                    }
-
-                    $price = (float) $rawPrice;
-                    if ($price <= 0) {
-                        continue;
-                    }
-
-                    $prices[] = [
-                        'date' => $day->format('Y-m-d'),
-                        'price' => $price,
-                    ];
                 }
             }
 
@@ -202,7 +191,7 @@ class GenericApiProvider implements InvestmentPriceProvider
     public function validateCredentials(array $credentials): void
     {
         $endpointUrl = isset($credentials['endpoint_url']) && is_string($credentials['endpoint_url'])
-            ? mb_trim($credentials['endpoint_url'])
+            ? Str::trim($credentials['endpoint_url'])
             : '';
 
         if ($endpointUrl === '') {
@@ -219,19 +208,21 @@ class GenericApiProvider implements InvestmentPriceProvider
             throw new PriceProviderException('Endpoint URL must be a valid URL.', 'generic_api');
         }
 
+        $this->assertPublicEndpointUrl($resolvedEndpointUrl, null);
+
         $datePath = isset($credentials['date_path']) && is_string($credentials['date_path'])
-            ? mb_trim($credentials['date_path'])
+            ? Str::trim($credentials['date_path'])
             : '';
 
         $pricePath = isset($credentials['price_path']) && is_string($credentials['price_path'])
-            ? mb_trim($credentials['price_path'])
+            ? Str::trim($credentials['price_path'])
             : '';
 
         $dateValuesPath = isset($credentials['date_values_path']) && is_string($credentials['date_values_path'])
-            ? mb_trim($credentials['date_values_path'])
+            ? Str::trim($credentials['date_values_path'])
             : '';
         $priceValuesPath = isset($credentials['price_values_path']) && is_string($credentials['price_values_path'])
-            ? mb_trim($credentials['price_values_path'])
+            ? Str::trim($credentials['price_values_path'])
             : '';
 
         if ($dateValuesPath !== '' || $priceValuesPath !== '') {
@@ -243,7 +234,7 @@ class GenericApiProvider implements InvestmentPriceProvider
         }
 
         $method = isset($credentials['http_method']) && is_string($credentials['http_method'])
-            ? mb_strtoupper(mb_trim($credentials['http_method']))
+            ? Str::upper(Str::trim($credentials['http_method']))
             : 'GET';
 
         if (! in_array($method, ['GET', 'POST'], true)) {
@@ -387,7 +378,7 @@ class GenericApiProvider implements InvestmentPriceProvider
     private function requiredStringCredential(array $credentials, string $key, Investment $investment): string
     {
         $value = isset($credentials[$key]) && is_string($credentials[$key])
-            ? mb_trim($credentials[$key])
+            ? Str::trim($credentials[$key])
             : '';
 
         if ($value === '') {
@@ -413,7 +404,7 @@ class GenericApiProvider implements InvestmentPriceProvider
         Investment $investment
     ): array {
         $value = isset($credentials[$key]) && is_string($credentials[$key])
-            ? mb_trim($credentials[$key])
+            ? Str::trim($credentials[$key])
             : '';
 
         if ($value === '') {
@@ -450,7 +441,7 @@ class GenericApiProvider implements InvestmentPriceProvider
     private function assertJsonObjectCredential(array $credentials, string $key): void
     {
         $value = isset($credentials[$key]) && is_string($credentials[$key])
-            ? mb_trim($credentials[$key])
+            ? Str::trim($credentials[$key])
             : '';
 
         if ($value === '') {
@@ -484,6 +475,130 @@ class GenericApiProvider implements InvestmentPriceProvider
         return strtr($value, $placeholders);
     }
 
+    private function assertPublicEndpointUrl(string $endpointUrl, ?string $investmentSymbol): void
+    {
+        $host = parse_url($endpointUrl, PHP_URL_HOST);
+
+        if (! is_string($host) || Str::trim($host) === '') {
+            throw new PriceProviderException(
+                'Endpoint URL must include a valid host.',
+                'generic_api',
+                $investmentSymbol
+            );
+        }
+
+        $normalizedHost = Str::lower(mb_trim($host, '[]'));
+
+        if ($normalizedHost === 'localhost') {
+            throw new PriceProviderException(
+                'Endpoint URL must resolve to a public IP address.',
+                'generic_api',
+                $investmentSymbol
+            );
+        }
+
+        $resolvedIps = $this->resolveEndpointIps($normalizedHost);
+
+        if ($resolvedIps === []) {
+            return;
+        }
+
+        foreach ($resolvedIps as $resolvedIp) {
+            if ($this->isDisallowedIp($resolvedIp)) {
+                throw new PriceProviderException(
+                    'Endpoint URL must resolve to a public IP address.',
+                    'generic_api',
+                    $investmentSymbol
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveEndpointIps(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        $resolvedIps = [];
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        if (is_array($records)) {
+            foreach ($records as $record) {
+                $ipAddress = $record['ip'] ?? $record['ipv6'] ?? null;
+
+                if (is_string($ipAddress) && $ipAddress !== '') {
+                    $resolvedIps[] = $ipAddress;
+                }
+            }
+        }
+
+        if ($resolvedIps === []) {
+            $ipv4Addresses = gethostbynamel($host);
+
+            if (is_array($ipv4Addresses)) {
+                foreach ($ipv4Addresses as $ipv4Address) {
+                    if ($ipv4Address !== '') {
+                        $resolvedIps[] = $ipv4Address;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($resolvedIps));
+    }
+
+    private function isDisallowedIp(string $ipAddress): bool
+    {
+        $normalizedIpAddress = Str::lower($ipAddress);
+
+        if (in_array($normalizedIpAddress, ['::1', '0:0:0:0:0:0:0:1'], true)) {
+            return true;
+        }
+
+        return filter_var(
+            $ipAddress,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) === false;
+    }
+
+    /**
+     * @param  mixed  $rawDate
+     * @param  mixed  $rawPrice
+     * @return array{date: string, price: float}|null
+     */
+    private function normalizeDatePrice(
+        mixed $rawDate,
+        mixed $rawPrice,
+        string $dateFormat,
+        ?Carbon $cutoff,
+        Investment $investment,
+    ): ?array {
+        if ($rawDate === null || $rawPrice === null || ! is_numeric($rawPrice)) {
+            return null;
+        }
+
+        $day = $this->parseDate($rawDate, $dateFormat, $investment);
+
+        if ($cutoff !== null && $day->lt($cutoff)) {
+            return null;
+        }
+
+        $price = (float) $rawPrice;
+        if ($price <= 0) {
+            return null;
+        }
+
+        return [
+            'date' => $day->format('Y-m-d'),
+            'price' => $price,
+        ];
+    }
+
     /**
      * @param  mixed  $rawDate
      */
@@ -503,6 +618,11 @@ class GenericApiProvider implements InvestmentPriceProvider
             }
 
             if (is_numeric($rawDate)) {
+                $strDate = (string) $rawDate;
+                if (preg_match('/^\d{8}$/', $strDate)) {
+                    return Carbon::createFromFormat('Ymd', $strDate)->startOfDay();
+                }
+
                 $timestamp = (float) $rawDate;
                 if ($timestamp > 9999999999) {
                     return Carbon::createFromTimestampMs((int) $timestamp)->startOfDay();

--- a/app/Services/InvestmentPriceProviders/GenericApiProvider.php
+++ b/app/Services/InvestmentPriceProviders/GenericApiProvider.php
@@ -1,0 +1,524 @@
+<?php
+
+namespace App\Services\InvestmentPriceProviders;
+
+use App\Contracts\InvestmentPriceProvider;
+use App\Exceptions\InvalidPriceDataException;
+use App\Exceptions\PriceProviderException;
+use App\Models\Investment;
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
+use Throwable;
+
+class GenericApiProvider implements InvestmentPriceProvider
+{
+    public function __construct(private Client $httpClient)
+    {
+    }
+
+    public function fetchPrices(Investment $investment, ?Carbon $from = null, bool $refill = false): array
+    {
+        $cutoff = $from
+            ? $from->copy()->startOfDay()
+            : ($refill ? null : Carbon::now()->subDays(5)->startOfDay());
+
+        $credentials = $investment->provider_credentials;
+
+        $endpointUrl = $this->requiredStringCredential($credentials, 'endpoint_url', $investment);
+
+        $method = mb_strtoupper((string) ($credentials['http_method'] ?? 'GET'));
+        if (! in_array($method, ['GET', 'POST'], true)) {
+            throw new InvalidPriceDataException(
+                'Unsupported HTTP method. Allowed values are GET and POST.',
+                'generic_api',
+                $investment->symbol
+            );
+        }
+
+        $placeholders = [
+            '{symbol}' => $investment->symbol,
+            '{from}' => $from?->copy()->startOfDay()->format('Y-m-d') ?? '',
+            '{to}' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        $resolvedEndpointUrl = $this->interpolate((string) $endpointUrl, $placeholders);
+
+        $headers = $this->parseJsonObjectCredential($credentials, 'headers_json', $placeholders, $investment);
+        $query = $this->parseJsonObjectCredential($credentials, 'query_json', $placeholders, $investment);
+        $body = $this->parseJsonObjectCredential($credentials, 'body_json', $placeholders, $investment);
+
+        try {
+            $requestOptions = [
+                'query' => $query,
+                'headers' => $headers,
+                'timeout' => 30,
+            ];
+
+            if ($method === 'POST' && $body !== []) {
+                $requestOptions['json'] = $body;
+            }
+
+            $response = $this->httpClient->request($method, $resolvedEndpointUrl, $requestOptions);
+            $decodedBody = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+            if (! is_array($decodedBody)) {
+                throw new InvalidPriceDataException(
+                    'Generic API returned an invalid JSON payload.',
+                    'generic_api',
+                    $investment->symbol
+                );
+            }
+
+            $prices = [];
+            $dateFormat = isset($credentials['date_format']) && is_string($credentials['date_format'])
+                ? mb_trim($credentials['date_format'])
+                : 'auto';
+
+            $dateValuesPath = isset($credentials['date_values_path']) && is_string($credentials['date_values_path'])
+                ? mb_trim($credentials['date_values_path'])
+                : '';
+            $priceValuesPath = isset($credentials['price_values_path']) && is_string($credentials['price_values_path'])
+                ? mb_trim($credentials['price_values_path'])
+                : '';
+
+            if ($dateValuesPath !== '' || $priceValuesPath !== '') {
+                $dateValues = data_get($decodedBody, $dateValuesPath);
+                $priceValues = data_get($decodedBody, $priceValuesPath);
+
+                if (! is_array($dateValues) || ! is_array($priceValues) || $dateValues === [] || $priceValues === []) {
+                    throw new InvalidPriceDataException(
+                        'No usable date/price arrays found at the configured parallel paths.',
+                        'generic_api',
+                        $investment->symbol
+                    );
+                }
+
+                foreach ($dateValues as $index => $rawDate) {
+                    $rawPrice = $priceValues[$index] ?? null;
+
+                    if ($rawDate === null || $rawPrice === null || ! is_numeric($rawPrice)) {
+                        continue;
+                    }
+
+                    $day = $this->parseDate($rawDate, $dateFormat, $investment);
+
+                    if ($cutoff !== null && $day->lt($cutoff)) {
+                        continue;
+                    }
+
+                    $price = (float) $rawPrice;
+                    if ($price <= 0) {
+                        continue;
+                    }
+
+                    $prices[] = [
+                        'date' => $day->format('Y-m-d'),
+                        'price' => $price,
+                    ];
+                }
+            } else {
+                $datePath = $this->requiredStringCredential($credentials, 'date_path', $investment);
+                $pricePath = $this->requiredStringCredential($credentials, 'price_path', $investment);
+
+                $itemsPath = isset($credentials['items_path']) && is_string($credentials['items_path'])
+                    ? mb_trim($credentials['items_path'])
+                    : '';
+
+                $items = $itemsPath === ''
+                    ? [$decodedBody]
+                    : data_get($decodedBody, $itemsPath);
+
+                if (! is_array($items) || $items === []) {
+                    throw new InvalidPriceDataException(
+                        'No price records found at the configured items path.',
+                        'generic_api',
+                        $investment->symbol
+                    );
+                }
+
+                foreach ($items as $item) {
+                    if (! is_array($item)) {
+                        continue;
+                    }
+
+                    $rawDate = data_get($item, $datePath);
+                    $rawPrice = data_get($item, $pricePath);
+
+                    if ($rawDate === null || $rawPrice === null || ! is_numeric($rawPrice)) {
+                        continue;
+                    }
+
+                    $day = $this->parseDate($rawDate, $dateFormat, $investment);
+
+                    if ($cutoff !== null && $day->lt($cutoff)) {
+                        continue;
+                    }
+
+                    $price = (float) $rawPrice;
+                    if ($price <= 0) {
+                        continue;
+                    }
+
+                    $prices[] = [
+                        'date' => $day->format('Y-m-d'),
+                        'price' => $price,
+                    ];
+                }
+            }
+
+            if ($prices === []) {
+                throw new InvalidPriceDataException(
+                    'No valid prices found in the API response.',
+                    'generic_api',
+                    $investment->symbol
+                );
+            }
+
+            return $prices;
+        } catch (InvalidPriceDataException $exception) {
+            throw $exception;
+        } catch (JsonException $exception) {
+            throw new PriceProviderException(
+                "Generic API invalid JSON response: {$exception->getMessage()}",
+                'generic_api',
+                $investment->symbol,
+                $exception
+            );
+        } catch (GuzzleException $exception) {
+            throw new PriceProviderException(
+                "Generic API request failed: {$exception->getMessage()}",
+                'generic_api',
+                $investment->symbol,
+                $exception
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $credentials
+     */
+    public function validateCredentials(array $credentials): void
+    {
+        $endpointUrl = isset($credentials['endpoint_url']) && is_string($credentials['endpoint_url'])
+            ? mb_trim($credentials['endpoint_url'])
+            : '';
+
+        if ($endpointUrl === '') {
+            throw new PriceProviderException('Endpoint URL is required.', 'generic_api');
+        }
+
+        $resolvedEndpointUrl = strtr($endpointUrl, [
+            '{symbol}' => 'AAPL',
+            '{from}' => '2024-01-01',
+            '{to}' => '2024-01-02',
+        ]);
+
+        if (! filter_var($resolvedEndpointUrl, FILTER_VALIDATE_URL)) {
+            throw new PriceProviderException('Endpoint URL must be a valid URL.', 'generic_api');
+        }
+
+        $datePath = isset($credentials['date_path']) && is_string($credentials['date_path'])
+            ? mb_trim($credentials['date_path'])
+            : '';
+
+        $pricePath = isset($credentials['price_path']) && is_string($credentials['price_path'])
+            ? mb_trim($credentials['price_path'])
+            : '';
+
+        $dateValuesPath = isset($credentials['date_values_path']) && is_string($credentials['date_values_path'])
+            ? mb_trim($credentials['date_values_path'])
+            : '';
+        $priceValuesPath = isset($credentials['price_values_path']) && is_string($credentials['price_values_path'])
+            ? mb_trim($credentials['price_values_path'])
+            : '';
+
+        if ($dateValuesPath !== '' || $priceValuesPath !== '') {
+            if ($dateValuesPath === '' || $priceValuesPath === '') {
+                throw new PriceProviderException('Both date_values_path and price_values_path are required when using parallel array mode.', 'generic_api');
+            }
+        } elseif ($datePath === '' || $pricePath === '') {
+            throw new PriceProviderException('Date path and price path are required.', 'generic_api');
+        }
+
+        $method = isset($credentials['http_method']) && is_string($credentials['http_method'])
+            ? mb_strtoupper(mb_trim($credentials['http_method']))
+            : 'GET';
+
+        if (! in_array($method, ['GET', 'POST'], true)) {
+            throw new PriceProviderException('HTTP method must be GET or POST.', 'generic_api');
+        }
+
+        $this->assertJsonObjectCredential($credentials, 'headers_json');
+        $this->assertJsonObjectCredential($credentials, 'query_json');
+        $this->assertJsonObjectCredential($credentials, 'body_json');
+    }
+
+    public function getName(): string
+    {
+        return 'generic_api';
+    }
+
+    public function getDisplayName(): string
+    {
+        return __('Custom API (Advanced)');
+    }
+
+    public function getDescription(): string
+    {
+        return __('Use the custom JSON API endpoint by defining request and parsing settings.');
+    }
+
+    public function getInstructions(): string
+    {
+        return __('Configure endpoint URL, optional headers/query/body JSON, and response paths for date and price. You can use placeholders like {symbol}, {from}, and {to} in URL and JSON fields.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getInvestmentSettingsSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'required' => [],
+            'properties' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getUserSettingsSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'required' => ['endpoint_url'],
+            'properties' => [
+                'endpoint_url' => [
+                    'type' => 'string',
+                    'format' => 'url',
+                    'allowPlaceholders' => true,
+                    'label' => __('Endpoint URL'),
+                    'minLength' => 8,
+                    'maxLength' => 2048,
+                ],
+                'http_method' => [
+                    'type' => 'string',
+                    'label' => __('HTTP method'),
+                    'enum' => ['GET', 'POST'],
+                    'maxLength' => 4,
+                ],
+                'headers_json' => [
+                    'type' => 'string',
+                    'label' => __('Headers (JSON object)'),
+                    'maxLength' => 10000,
+                ],
+                'query_json' => [
+                    'type' => 'string',
+                    'label' => __('Query params (JSON object)'),
+                    'maxLength' => 10000,
+                ],
+                'body_json' => [
+                    'type' => 'string',
+                    'label' => __('Body (JSON object, POST only)'),
+                    'maxLength' => 20000,
+                ],
+                'items_path' => [
+                    'type' => 'string',
+                    'label' => __('Items path'),
+                    'maxLength' => 255,
+                ],
+                'date_path' => [
+                    'type' => 'string',
+                    'label' => __('Date path'),
+                    'minLength' => 1,
+                    'maxLength' => 255,
+                ],
+                'price_path' => [
+                    'type' => 'string',
+                    'label' => __('Price path'),
+                    'minLength' => 1,
+                    'maxLength' => 255,
+                ],
+                'date_values_path' => [
+                    'type' => 'string',
+                    'label' => __('Date values path (parallel array mode)'),
+                    'maxLength' => 255,
+                ],
+                'price_values_path' => [
+                    'type' => 'string',
+                    'label' => __('Price values path (parallel array mode)'),
+                    'maxLength' => 255,
+                ],
+                'date_format' => [
+                    'type' => 'string',
+                    'label' => __('Date format'),
+                    'enum' => ['auto', 'Y-m-d', 'timestamp_seconds', 'timestamp_milliseconds'],
+                    'maxLength' => 24,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRateLimitPolicy(): array
+    {
+        return [
+            'perSecond' => null,
+            'perMinute' => 10,
+            'perDay' => 1000,
+            'reserve' => 0,
+            'overrideable' => true,
+        ];
+    }
+
+    public function supportsHistoricalSync(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $credentials
+     */
+    private function requiredStringCredential(array $credentials, string $key, Investment $investment): string
+    {
+        $value = isset($credentials[$key]) && is_string($credentials[$key])
+            ? mb_trim($credentials[$key])
+            : '';
+
+        if ($value === '') {
+            throw new InvalidPriceDataException(
+                __('Missing required configuration field: :field', ['field' => $key]),
+                'generic_api',
+                $investment->symbol
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $credentials
+     * @param  array<string, string>  $placeholders
+     * @return array<string, mixed>
+     */
+    private function parseJsonObjectCredential(
+        array $credentials,
+        string $key,
+        array $placeholders,
+        Investment $investment
+    ): array {
+        $value = isset($credentials[$key]) && is_string($credentials[$key])
+            ? mb_trim($credentials[$key])
+            : '';
+
+        if ($value === '') {
+            return [];
+        }
+
+        $resolvedValue = $this->interpolate($value, $placeholders);
+
+        try {
+            $decoded = json_decode($resolvedValue, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidPriceDataException(
+                __('Invalid JSON in :field: :message', ['field' => $key, 'message' => $exception->getMessage()]),
+                'generic_api',
+                $investment->symbol,
+                $exception
+            );
+        }
+
+        if (! is_array($decoded)) {
+            throw new InvalidPriceDataException(
+                __('Field :field must contain a JSON object.', ['field' => $key]),
+                'generic_api',
+                $investment->symbol
+            );
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $credentials
+     */
+    private function assertJsonObjectCredential(array $credentials, string $key): void
+    {
+        $value = isset($credentials[$key]) && is_string($credentials[$key])
+            ? mb_trim($credentials[$key])
+            : '';
+
+        if ($value === '') {
+            return;
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new PriceProviderException(
+                __('Invalid JSON in :field: :message', ['field' => $key, 'message' => $exception->getMessage()]),
+                'generic_api',
+                null,
+                $exception
+            );
+        }
+
+        if (! is_array($decoded)) {
+            throw new PriceProviderException(
+                __('Field :field must contain a JSON object.', ['field' => $key]),
+                'generic_api'
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $placeholders
+     */
+    private function interpolate(string $value, array $placeholders): string
+    {
+        return strtr($value, $placeholders);
+    }
+
+    /**
+     * @param  mixed  $rawDate
+     */
+    private function parseDate(mixed $rawDate, string $dateFormat, Investment $investment): Carbon
+    {
+        try {
+            if ($dateFormat === 'timestamp_seconds') {
+                return Carbon::createFromTimestamp((int) $rawDate)->startOfDay();
+            }
+
+            if ($dateFormat === 'timestamp_milliseconds') {
+                return Carbon::createFromTimestampMs((int) $rawDate)->startOfDay();
+            }
+
+            if ($dateFormat === 'Y-m-d') {
+                return Carbon::createFromFormat('Y-m-d', (string) $rawDate)->startOfDay();
+            }
+
+            if (is_numeric($rawDate)) {
+                $timestamp = (float) $rawDate;
+                if ($timestamp > 9999999999) {
+                    return Carbon::createFromTimestampMs((int) $timestamp)->startOfDay();
+                }
+
+                return Carbon::createFromTimestamp((int) $timestamp)->startOfDay();
+            }
+
+            return Carbon::parse((string) $rawDate)->startOfDay();
+        } catch (Throwable $exception) {
+            throw new InvalidPriceDataException(
+                'Unable to parse date value returned by Generic API.',
+                'generic_api',
+                $investment->symbol,
+                $exception
+            );
+        }
+    }
+}

--- a/resources/js/user/InvestmentProviderSettings.vue
+++ b/resources/js/user/InvestmentProviderSettings.vue
@@ -89,6 +89,10 @@
             </div>
 
             <div v-else>
+              <div v-if="provider.instructions" class="form-text mb-3">
+                {{ provider.instructions }}
+              </div>
+
               <div class="row g-4">
                 <div
                   v-for="field in credentialFields(provider)"
@@ -108,8 +112,8 @@
                     class="form-control"
                     :placeholder="credentialPlaceholder(provider, field.key)"
                   />
-                  <div class="form-text mt-2" v-if="provider.instructions">
-                    {{ provider.instructions }}
+                  <div class="form-text mt-2" v-if="field.schema.helpText">
+                    {{ field.schema.helpText }}
                   </div>
                 </div>
 

--- a/tests/Feature/API/V1/InvestmentPriceProviderApiV1Test.php
+++ b/tests/Feature/API/V1/InvestmentPriceProviderApiV1Test.php
@@ -67,6 +67,7 @@ class InvestmentPriceProviderApiV1Test extends TestCase
 
         $this->assertTrue($providers->has('alpha_vantage'));
         $this->assertTrue($providers->has('web_scraping'));
+        $this->assertFalse($providers->has('generic_api'));
         $this->assertTrue($providers->get('alpha_vantage')['available']);
         $this->assertSame('Configured', $providers->get('alpha_vantage')['statusLabel']);
         $this->assertTrue($providers->get('web_scraping')['available']);
@@ -87,6 +88,10 @@ class InvestmentPriceProviderApiV1Test extends TestCase
         $this->assertSame(['setup_required'], $providers->get('alpha_vantage')['reasonFlags']);
         $this->assertTrue($providers->has('web_scraping'));
         $this->assertTrue($providers->get('web_scraping')['available']);
+        $this->assertTrue($providers->has('generic_api'));
+        $this->assertFalse($providers->get('generic_api')['available']);
+        $this->assertSame('Setup required', $providers->get('generic_api')['statusLabel']);
+        $this->assertSame(['setup_required'], $providers->get('generic_api')['reasonFlags']);
     }
 
     public function test_test_fetch_requires_symbol_for_all_providers(): void

--- a/tests/Feature/API/V1/InvestmentProviderConfigApiV1Test.php
+++ b/tests/Feature/API/V1/InvestmentProviderConfigApiV1Test.php
@@ -134,6 +134,54 @@ class InvestmentProviderConfigApiV1Test extends TestCase
             ->assertJsonValidationErrors(['credentials.api_key']);
     }
 
+    public function test_update_validates_required_credentials_for_generic_api(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson(route('api.v1.investment-provider-configs.update', ['providerKey' => 'generic_api']), [
+                'credentials' => [
+                    'http_method' => 'GET',
+                ],
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors([
+                'credentials.endpoint_url',
+                'credentials.date_path',
+                'credentials.price_path',
+            ]);
+    }
+
+    public function test_update_allows_placeholder_url_and_parallel_array_mode_for_generic_api(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson(route('api.v1.investment-provider-configs.update', ['providerKey' => 'generic_api']), [
+                'credentials' => [
+                    'endpoint_url' => 'https://query1.finance.yahoo.com/v8/finance/chart/{symbol}',
+                    'date_values_path' => 'chart.result.0.timestamp',
+                    'price_values_path' => 'chart.result.0.indicators.quote.0.close',
+                    'date_format' => 'timestamp_seconds',
+                ],
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('provider_key', 'generic_api')
+            ->assertJsonPath('has_credentials', true);
+    }
+
+    public function test_update_requires_both_parallel_paths_when_parallel_mode_is_used_for_generic_api(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson(route('api.v1.investment-provider-configs.update', ['providerKey' => 'generic_api']), [
+                'credentials' => [
+                    'endpoint_url' => 'https://query1.finance.yahoo.com/v8/finance/chart/{symbol}',
+                    'date_values_path' => 'chart.result.0.timestamp',
+                ],
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['credentials.price_values_path']);
+    }
+
     public function test_update_rejects_overrides_for_non_overrideable_provider(): void
     {
         $response = $this->actingAs($this->user)

--- a/tests/Unit/Services/InvestmentPriceProviders/GenericApiProviderTest.php
+++ b/tests/Unit/Services/InvestmentPriceProviders/GenericApiProviderTest.php
@@ -140,6 +140,42 @@ class GenericApiProviderTest extends TestCase
             'date_format' => 'timestamp_seconds',
         ]);
 
-        $this->assertTrue(true);
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_validate_credentials_rejects_localhost_endpoint(): void
+    {
+        $provider = new GenericApiProvider($this->createMock(Client::class));
+
+        $this->expectException(PriceProviderException::class);
+        $this->expectExceptionMessage('Endpoint URL must resolve to a public IP address.');
+
+        $provider->validateCredentials([
+            'endpoint_url' => 'http://localhost:8080/prices',
+            'date_path' => 'data.0.date',
+            'price_path' => 'data.0.close',
+        ]);
+    }
+
+    public function test_fetch_prices_rejects_loopback_endpoint_before_request(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->never())->method('request');
+
+        $provider = new GenericApiProvider($client);
+
+        $investment = new Investment([
+            'symbol' => 'MSFT',
+        ]);
+        $investment->provider_credentials = [
+            'endpoint_url' => 'http://127.0.0.1/prices/{symbol}',
+            'date_path' => 'date',
+            'price_path' => 'close',
+        ];
+
+        $this->expectException(PriceProviderException::class);
+        $this->expectExceptionMessage('Endpoint URL must resolve to a public IP address.');
+
+        $provider->fetchPrices($investment);
     }
 }

--- a/tests/Unit/Services/InvestmentPriceProviders/GenericApiProviderTest.php
+++ b/tests/Unit/Services/InvestmentPriceProviders/GenericApiProviderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit\Services\InvestmentPriceProviders;
+
+use App\Exceptions\PriceProviderException;
+use App\Models\Investment;
+use App\Services\InvestmentPriceProviders\GenericApiProvider;
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Tests\TestCase;
+
+class GenericApiProviderTest extends TestCase
+{
+    public function test_fetch_prices_parses_items_and_normalizes_dates(): void
+    {
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://api.example.com/prices?symbol=AAPL',
+                [
+                    'query' => [
+                        'market' => 'us',
+                    ],
+                    'headers' => [
+                        'Accept' => 'application/json',
+                    ],
+                    'timeout' => 30,
+                ]
+            )
+            ->willReturn(new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        'date' => '2026-06-06',
+                        'close' => '123.45',
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)));
+
+        $provider = new GenericApiProvider($client);
+
+        $investment = new Investment([
+            'symbol' => 'AAPL',
+        ]);
+        $investment->provider_credentials = [
+            'endpoint_url' => 'https://api.example.com/prices?symbol={symbol}',
+            'headers_json' => '{"Accept":"application/json"}',
+            'query_json' => '{"market":"us"}',
+            'items_path' => 'data',
+            'date_path' => 'date',
+            'price_path' => 'close',
+            'date_format' => 'Y-m-d',
+        ];
+
+        $prices = $provider->fetchPrices($investment, Carbon::create(2026, 6, 1));
+
+        $this->assertSame([
+            [
+                'date' => '2026-06-06',
+                'price' => 123.45,
+            ],
+        ], $prices);
+    }
+
+    public function test_validate_credentials_rejects_invalid_json_fields(): void
+    {
+        $provider = new GenericApiProvider($this->createMock(Client::class));
+
+        $this->expectException(PriceProviderException::class);
+        $this->expectExceptionMessage('Invalid JSON in headers_json');
+
+        $provider->validateCredentials([
+            'endpoint_url' => 'https://api.example.com/prices?symbol={symbol}',
+            'date_path' => 'data.0.date',
+            'price_path' => 'data.0.close',
+            'headers_json' => '{invalid',
+        ]);
+    }
+
+    public function test_fetch_prices_supports_parallel_date_and_price_arrays(): void
+    {
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('request')
+            ->willReturn(new Response(200, [], json_encode([
+                'chart' => [
+                    'result' => [
+                        [
+                            'timestamp' => [1717718400, 1717804800],
+                            'indicators' => [
+                                'quote' => [
+                                    [
+                                        'close' => [99.5, 101.2],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)));
+
+        $provider = new GenericApiProvider($client);
+
+        $investment = new Investment([
+            'symbol' => 'AGGG.L',
+        ]);
+        $investment->provider_credentials = [
+            'endpoint_url' => 'https://query1.finance.yahoo.com/v8/finance/chart/{symbol}',
+            'date_values_path' => 'chart.result.0.timestamp',
+            'price_values_path' => 'chart.result.0.indicators.quote.0.close',
+            'date_format' => 'timestamp_seconds',
+        ];
+
+        $prices = $provider->fetchPrices($investment, Carbon::create(2024, 6, 7));
+
+        $this->assertSame([
+            [
+                'date' => '2024-06-07',
+                'price' => 99.5,
+            ],
+            [
+                'date' => '2024-06-08',
+                'price' => 101.2,
+            ],
+        ], $prices);
+    }
+
+    public function test_validate_credentials_allows_placeholders_in_endpoint_url(): void
+    {
+        $provider = new GenericApiProvider($this->createMock(Client::class));
+
+        $provider->validateCredentials([
+            'endpoint_url' => 'https://query1.finance.yahoo.com/v8/finance/chart/{symbol}',
+            'date_values_path' => 'chart.result.0.timestamp',
+            'price_values_path' => 'chart.result.0.indicators.quote.0.close',
+            'date_format' => 'timestamp_seconds',
+        ]);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Adds a new "Generic API" investment price provider, enabling users to fetch prices from any custom JSON HTTP API. This significantly enhances flexibility for integrating with diverse market data sources.

*   **Implements Generic API Provider**: Introduces a new provider that allows users to define custom HTTP requests (GET/POST, URL, headers, query, body) and parse JSON responses for date and price data.
*   **Supports Flexible Parsing Modes**: Provides two primary modes for extracting data:
    *   **Object-Item Mode**: Extracts date and price from individual objects within an array.
    *   **Parallel-Array Mode**: Extracts dates and prices from separate, synchronized arrays.
*   **Includes Placeholder Support**: Allows dynamic substitution of `{symbol}`, `{from}`, and `{to}` in the endpoint URL, headers, query parameters, and request body.
*   **Enhances Configuration Validation**: Adds robust server-side validation for the generic API's credentials, including conditional requirements for date and price paths based on the chosen parsing mode, and URL validation that accounts for placeholders.
*   **Provides Detailed Documentation**: Creates comprehensive documentation outlining the configuration fields, backend endpoints, parsing examples, placeholder rules, and testing procedures.
*   **Updates UI for Instructions**: Integrates provider-specific and field-level instructions into the investment provider settings UI to guide users through the complex configuration process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a generic API investment price provider for fetching prices from configurable HTTP JSON endpoints with flexible parsing modes and URL placeholder support

* **Documentation**
  * Added a configuration guide describing credential fields, parsing modes, placeholder rules, validation behavior, and example payloads

* **Improvements**
  * Settings UI now shows provider-level instructions separately and field-specific help text

* **Tests**
  * Added coverage for provider behavior, credential validation, endpoint validation, and parsing modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->