### PR TITLE
feat: adopts official MySQL Docker image

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -36,8 +36,8 @@ jobs:
           sed -i 's|^DB_HOST=.*|DB_HOST=db|' docker/.env
           sed -i "s|^APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|" docker/.env
 
-      - name: Start stack
-        run: docker compose -f docker/docker-compose.yml up -d
+      - name: Start core services
+        run: docker compose -f docker/docker-compose.yml up -d db redis app
 
       - name: Wait for services
         run: |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,11 +1,27 @@
-# Upgrade guide for major versions
+# Upgrade guide
 
-This document describes the breaking changes of major versions, and the steps that need to be performed to get you migrated.
+This document describes the breaking changes of major versions, and also includes notable upgrade notes for changes within a major version when extra operator action is recommended.
 
 Table of contents:
 
+- [Upgrade within YAFFA 3.x](#upgrade-within-yaffa-3x)
 - [Upgrade from YAFFA 2.x to 3.x](#upgrade-from-yaffa-2x-to-3x)
 - [Upgrade from YAFFA 1.x to 2.x](#upgrade-from-yaffa-1x-to-2x)
+
+## Upgrade within YAFFA 3.x
+
+Most 3.x upgrades do not require any special manual steps beyond the usual application update procedure for your hosting option.
+
+### Docker users switching from `mysql/mysql-server:8.0` to `mysql:8.0`
+
+If the updated `docker-compose.yml` changes the database image from `mysql/mysql-server:8.0` to `mysql:8.0`, review the Docker notes in the 3.x upgrade section below before restarting the stack.
+
+In particular:
+
+- Keep the existing named database volume so the new container reuses the current data directory.
+- Make sure `DB_HOST` still matches the database service name from your Docker Compose file. In the packaged YAFFA Docker setup, the service is named `db`.
+- Verify that your Docker deployment does not use `DB_USERNAME=root`, because the official `mysql` image does not support initializing `MYSQL_USER=root`.
+- Prefer restarting the database first, then the YAFFA application containers, to minimize user impact during the first startup on the new image.
 
 ## Upgrade from YAFFA 2.x to 3.x
 
@@ -144,12 +160,23 @@ From this point, the steps differ depending on your hosting option. Follow only 
    - Decide whether to use Tesseract OCR as a local service. It is disabled by default and not needed if you only use a Vision AI model for document processing, or if you don't use document processing at all.
    - If you want to use Tesseract OCR, uncomment the relevant lines in the `depends_on` section of the `app` service and uncomment the entire `tesseract` service definition.
    - If using Tesseract in `http` mode, set `TESSERACT_HTTP_HOST` to the Docker service name (e.g., `tesseract`) and set `TESSERACT_ENABLED=true`.
+   - Make sure `DB_HOST` matches the database service name in the compose file. In the default packaged Docker setup, this is `db`.
+   - If you are updating to a compose file that switches the database image from `mysql/mysql-server:8.0` to `mysql:8.0`, keep the existing named database volume in place. This allows the upgraded container to reuse the current data directory instead of initializing a fresh database.
+   - Before the first start on the new MySQL image, verify that your Docker deployment does not use `DB_USERNAME=root`. The official `mysql` image does not support initializing `MYSQL_USER=root`. Use a dedicated application user instead, such as the default `yaffa_user` from `.env.example`.
 
 2. **Pull the latest image and restart your container**:
+
    ```bash
    docker compose pull
-   docker compose up -d
+   docker compose stop app scheduler
+   docker compose up -d db
+   docker compose up -d app scheduler
    ```
+
+   This restart order minimizes user impact during the MySQL image swap by letting the database finish its first startup on the new image before YAFFA reconnects.
+
+   If you use different service names, adapt the commands accordingly. Avoid removing the database volume unless you intentionally want a fresh empty database.
+
    The container entrypoint automatically runs migrations, clears caches, and rebuilds assets on startup. No further action is required.
 
 ##### Source code users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - sail
     stop_grace_period: 1m
     healthcheck:
-      test: ['CMD', 'mysqladmin', 'ping', '-p${DB_PASSWORD}']
+      test: ['CMD', 'mysqladmin', 'ping', '-uroot', '-p${DB_PASSWORD}']
       start_period: 30s
       retries: 3
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - mailhog
       - selenium
   mysql:
-    image: 'mysql/mysql-server:8.0'
+    image: 'mysql:8.0'
     ports:
       - '${FORWARD_DB_PORT:-3306}:3306'
     environment:
@@ -41,8 +41,10 @@ services:
       - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
     networks:
       - sail
+    stop_grace_period: 1m
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-p${DB_PASSWORD}']
+      start_period: 30s
       retries: 3
       timeout: 5s
   mailhog:

--- a/docker-smoke-test.sh
+++ b/docker-smoke-test.sh
@@ -30,8 +30,8 @@ cp .env.example docker/.env
 sed -i 's|^DB_HOST=.*|DB_HOST=db|' docker/.env
 sed -i "s|^APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|" docker/.env
 
-print_step "Starting stack"
-docker compose -f "$COMPOSE_FILE" up -d
+print_step "Starting core services"
+docker compose -f "$COMPOSE_FILE" up -d db redis app
 
 print_step "Waiting for services to start"
 for i in $(seq 1 "$HEALTH_CHECK_RETRIES"); do
@@ -99,8 +99,14 @@ else
 fi
 
 print_step "Triggering Laravel log entry"
-ESCAPED_MESSAGE=$(printf '%s' "$TEST_LOG_MESSAGE" | sed "s/'/\\\\'/g")
-docker exec "$APP_CONTAINER" php artisan tinker --execute="Log::error('${ESCAPED_MESSAGE}');"
+LOG_OUTPUT=$(docker exec -e TEST_LOG_MESSAGE="$TEST_LOG_MESSAGE" "$APP_CONTAINER" php -r 'require "vendor/autoload.php"; $app = require "bootstrap/app.php"; $kernel = $app->make(Illuminate\\Contracts\\Console\\Kernel::class); $kernel->bootstrap(); Illuminate\\Support\\Facades\\Log::error(getenv("TEST_LOG_MESSAGE"));' 2>&1 || true)
+echo "$LOG_OUTPUT"
+
+if echo "$LOG_OUTPUT" | grep -q "$TEST_LOG_MESSAGE"; then
+  echo "Laravel stderr logging verified via docker exec output"
+else
+  echo "Log entry not printed directly by docker exec; checking container logs"
+fi
 
 print_step "Checking Laravel stderr logging"
 for i in $(seq 1 10); do

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,10 @@ services:
     volumes:
       - yaffa_storage:/var/www/html/storage
     depends_on:
+      # Keep startup serialized for first-run named-volume initialization on
+      # shared storage to avoid sporadic Docker mkdir/file-exists races.
+      app:
+        condition: service_healthy
       db:
         condition: service_healthy
       redis:
@@ -113,7 +117,7 @@ services:
           '-h',
           'localhost',
           '-u',
-          '${DB_USERNAME}',
+          'root',
           '-p${DB_PASSWORD}',
         ]
       interval: 30s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   # MySQL database container to store Yaffa data
   db:
-    image: mysql/mysql-server:8.0
+    image: mysql:8.0
     ports:
       - '${FORWARD_DB_PORT:-3306}:3306'
     environment:
@@ -101,6 +101,7 @@ services:
     volumes:
       - yaffa_db:/var/lib/mysql
     restart: unless-stopped
+    stop_grace_period: 1m
     networks:
       - yaffa-network
     healthcheck:
@@ -116,6 +117,7 @@ services:
           '-p${DB_PASSWORD}',
         ]
       interval: 30s
+      start_period: 30s
       timeout: 10s
       retries: 3
 


### PR DESCRIPTION
*   Migrates the default Docker Compose configuration from `mysql/mysql-server:8.0` to the official `mysql:8.0` image.
*   Enhances the `UPGRADE.md` with detailed instructions for this database image transition. Guidance includes retaining data volumes, verifying database hostnames, configuring non-root users, and optimizing container restart order to minimize user impact.
*   Adds `stop_grace_period` and `start_period` settings to the database service health checks, improving container resilience during startup and shutdown.
*   Introduces a new "Upgrade within YAFFA 3.x" section in the upgrade guide to better document notable changes that may require operator action between major versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced upgrade instructions with Docker-specific guidance for migrating MySQL (preserve named DB volume, ensure DB host/service matches, avoid using root as DB user) and a staged container restart procedure to minimize impact.

* **Chores**
  * Switched to a canonical MySQL image and improved container health checks and graceful shutdown timing; added serialized startup for dependent services.

* **Tests**
  * Smoke tests now start core services explicitly and use a more reliable in-container log verification step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->