### PR TITLE
Enables direct actions on schedule calendar

### DIFF
--- a/.ai/docs/features/dashboard/schedule-calendar.md
+++ b/.ai/docs/features/dashboard/schedule-calendar.md
@@ -6,7 +6,7 @@ Upcoming Scheduled Transactions Calendar
 
 ## Feature Summary
 
-This widget places scheduled transaction instances on a calendar so users can quickly see what is coming up next. It is a future-awareness tool designed to reduce surprises and keep recurring financial commitments visible.
+This widget places scheduled transaction instances on a calendar so users can quickly see what is coming up next. It is a future-awareness tool designed to reduce surprises and keep recurring financial commitments visible, while also allowing users to act on a scheduled instance directly from the calendar.
 
 ## Target User
 
@@ -20,15 +20,17 @@ This widget places scheduled transaction instances on a calendar so users can qu
 
 - Scheduled commitments are easy to forget when they are hidden inside forms or lists.
 - Users need a visual way to see near-future financial activity without running a full report.
-- Provides a quick link to enter scheduled instances when they are top of mind.
+- Users need a quick way to either enter or skip a scheduled instance when it is top of mind.
 
 ## User Value / Benefit
 
 ### Functional Benefits
 
 - Displays upcoming scheduled instances in calendar form.
-- Lets users click through directly to the enter-instance workflow.
+- Lets users open the enter-instance workflow directly from the calendar.
+- Lets users skip the current scheduled instance without leaving the calendar.
 - Makes upcoming planned activity visible in a time-based layout.
+- Keeps the user on the same month when the widget refreshes after an action.
 
 ### Conceptual Benefits
 
@@ -49,8 +51,9 @@ Use this widget when the user wants to know What is scheduled soon?
 
 - The widget loads scheduled transaction items from the existing transaction API.
 - It maps next scheduled dates into a calendar component.
-- Each date cell can contain one or more transaction-type icons that link to the related entry action.
-- The visible date range is automatically adjusted to the relevant upcoming period.
+- Each date cell can contain one or more transaction-type icons that open an interactive popover.
+- The popover lets the user skip the current instance or enter it through the existing transaction modal flow.
+- The visible month is preserved when the widget refreshes after user actions.
 
 ## Inputs
 
@@ -61,14 +64,17 @@ Use this widget when the user wants to know What is scheduled soon?
 ## Outputs
 
 - Calendar with scheduled-instance markers
-- Tooltip-style labels for transaction details
-- Direct navigation into the schedule entry workflow
+- Interactive popover with transaction details and action buttons
+- Skip action result reflected back into the calendar data
+- Direct entry into the schedule workflow through the modal-based form
 
 ## Core Logic / Rules
 
 - Only items with a valid next scheduled date are shown.
 - The calendar focuses on schedule instances rather than the full transaction history.
 - The widget is a visibility tool, not a full schedule-management interface.
+- The popover can stay open long enough for interaction and closes when the calendar moves or the widget is dismissed.
+- After skipping or saving an instance, the widget refreshes its schedule data and keeps the visible month stable when possible.
 
 ## Confidence Level
 
@@ -76,4 +82,4 @@ High
 
 ## Assumptions
 
-- The widget is mainly oriented toward awareness and follow-up rather than detailed schedule editing.
+- The widget is mainly oriented toward awareness and follow-up rather than detailed schedule editing, even though it now supports two lightweight actions on each upcoming instance.

--- a/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
+++ b/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
@@ -44,6 +44,11 @@
                 class="btn btn-link p-0 schedule-calendar-trigger"
                 @mouseenter="onTransactionTriggerEnter($event, item.customData)"
                 @mouseleave="onTransactionTriggerLeave"
+                @click="onTransactionTriggerClick($event, item.customData)"
+                @keydown="onTransactionTriggerKeydown($event, item.customData)"
+                @touchstart="
+                  onTransactionTriggerTouchstart($event, item.customData)
+                "
                 @focus="onTransactionTriggerEnter($event, item.customData)"
                 @blur="onTransactionTriggerLeave"
               >
@@ -98,6 +103,7 @@
         popoverHideDelayMs: 1500,
         skipInstanceBusy: false,
         visiblePage: null,
+        preventGhostClickUntil: 0,
       };
     },
 
@@ -350,6 +356,33 @@
       },
       onTransactionTriggerLeave() {
         this.schedulePopoverHide();
+      },
+      onTransactionTriggerClick(event, transaction) {
+        if (Date.now() < this.preventGhostClickUntil) {
+          event.preventDefault();
+          return;
+        }
+
+        this.onTransactionTriggerEnter(event, transaction);
+      },
+      onTransactionTriggerKeydown(event, transaction) {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+          return;
+        }
+
+        event.preventDefault();
+        this.onTransactionTriggerEnter(event, transaction);
+      },
+      preventGhostClick(event) {
+        this.preventGhostClickUntil = Date.now() + 700;
+
+        if (event.cancelable) {
+          event.preventDefault();
+        }
+      },
+      onTransactionTriggerTouchstart(event, transaction) {
+        this.onTransactionTriggerEnter(event, transaction);
+        this.preventGhostClick(event);
       },
       async skipInstance(transactionId, buttonElement = null) {
         if (this.skipInstanceBusy) {

--- a/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
+++ b/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card mb-4" id="widgetScheduleCalendar">
+  <div id="widgetScheduleCalendar" class="card mb-4">
     <div class="card-header d-flex justify-content-between">
       <div class="card-title">
         {{ __('widget.scheduleCalendar.cardTitle') }}
@@ -9,16 +9,17 @@
           type="button"
           class="btn-close"
           aria-label="Close"
-          @click="hide"
           :disabled="busy"
+          @click="hide"
         ></button>
       </div>
     </div>
     <div class="card-body">
-      <p aria-hidden="true" v-if="busy" class="placeholder-glow">
+      <p v-if="busy" aria-hidden="true" class="placeholder-glow">
         <span class="placeholder col-12"></span>
       </p>
       <Calendar
+        ref="calendar"
         class="custom-calendar"
         :masks="masks"
         :attributes="transactions"
@@ -28,21 +29,26 @@
         disable-page-swipe
         expanded
         trim-weeks
-        @transition-end="refreshTooltip"
-        v-if="!busy"
         :locale="language"
+        @transition-start="onCalendarTransitionStart"
+        @update:pages="handlePagesUpdate"
       >
-        <template v-slot:day-content="{ day, attributes }">
+        <template #day-content="{ day, attributes }">
           <div>
             <span class="day-label text-sm">{{ day.day }}</span>
             <div class="vc-day-custom-content">
-              <a
+              <button
                 v-for="item in attributes"
                 :key="item.key"
-                style="margin: 0 1px"
-                :href="getTransactionLink(item.customData?.id || 0)"
-                v-html="getTransactionTypeIcon(item.customData)"
-              ></a>
+                type="button"
+                class="btn btn-link p-0 schedule-calendar-trigger"
+                @mouseenter="onTransactionTriggerEnter($event, item.customData)"
+                @mouseleave="onTransactionTriggerLeave"
+                @focus="onTransactionTriggerEnter($event, item.customData)"
+                @blur="onTransactionTriggerLeave"
+              >
+                <i :class="getTransactionIconClasses(item.customData)"></i>
+              </button>
             </div>
           </div>
         </template>
@@ -52,9 +58,13 @@
 </template>
 
 <script>
-  import { transactionTypeIcon } from '@/shared/lib/datatable';
-  import { initializeBootstrapTooltips } from '@/shared/lib/helpers';
+  import {
+    escapeHtml,
+    escapeHtmlWithLineBreaks,
+    getTransactionTypeConfig,
+  } from '@/shared/lib/helpers';
   import { __, toFormattedCurrency } from '@/shared/lib/i18n';
+  import * as toastHelpers from '@/shared/lib/toast';
   import { Calendar } from 'v-calendar';
 
   export default {
@@ -73,56 +83,6 @@
       },
     },
 
-    methods: {
-      getTransactionTypeIcon: function (transaction) {
-        if (!transaction) {
-          return '';
-        }
-
-        return transactionTypeIcon(
-          transaction.transaction_type,
-          this.getTransactionLabel(transaction),
-        );
-      },
-      getTransactionLink: function (id) {
-        return this.route('transaction.open', {
-          transaction: id,
-          action: 'enter',
-        });
-      },
-      getTransactionLabel: function (transaction) {
-        if (!transaction) {
-          return '';
-        }
-
-        if (transaction.config_type === 'standard') {
-          // Capitalize first letter of transaction type
-          const type =
-            transaction.transaction_type.charAt(0).toUpperCase() +
-            transaction.transaction_type.slice(1);
-          // Return constructed label
-          return this.__('widget.scheduleCalendar.transactionLabel', {
-            type: __(type), // Type itself is also translated before being inserted into the label
-            amount: toFormattedCurrency(
-              transaction.config.amount_to,
-              this.locale,
-              transaction.transaction_currency,
-            ),
-            fromAccount: transaction.config.account_from.name,
-            toAccount: transaction.config.account_to.name,
-          });
-        }
-      },
-      refreshTooltip: function () {
-        initializeBootstrapTooltips();
-      },
-      __,
-      toFormattedCurrency,
-      hide() {
-        $('#widgetScheduleCalendar').hide();
-      },
-    },
-
     data() {
       return {
         busy: false,
@@ -132,26 +92,427 @@
         },
         minDate: null,
         maxDate: null,
+        activePopover: null,
+        activePopoverTrigger: null,
+        popoverHideTimer: null,
+        popoverHideDelayMs: 1000,
+        skipInstanceBusy: false,
+        visiblePage: null,
       };
     },
 
     created() {
-      this.busy = true;
-      let vue = this;
+      this.loadTransactions();
+      window.addEventListener(
+        'transaction-created',
+        this.handleTransactionCreated,
+      );
+    },
 
-      axios
-        .get('/api/v1/transactions/scheduled-items?type=schedule')
-        .then(function (response) {
-          vue.transactions = response.data.transactions
-            // Keep only the transactions with a next date set.
-            // Note: the date values are not converted to JavaScript Date objects in general.
-            // Note: at this point, all items should have a schedule and next date, but a double-check is performed
+    mounted() {
+      document.addEventListener('click', this.onPopoverActionClick);
+    },
+
+    beforeUnmount() {
+      document.removeEventListener('click', this.onPopoverActionClick);
+      window.removeEventListener(
+        'transaction-created',
+        this.handleTransactionCreated,
+      );
+      this.disposeActivePopover();
+    },
+
+    methods: {
+      getTransactionIconClasses(transaction) {
+        if (!transaction) {
+          return [];
+        }
+
+        const typeConfig = getTransactionTypeConfig(
+          transaction.transaction_type,
+        );
+
+        if (typeConfig.category === 'standard') {
+          if (transaction.transaction_type === 'withdrawal') {
+            return ['fa', 'fa-circle-minus', 'text-danger'];
+          }
+          if (transaction.transaction_type === 'deposit') {
+            return ['fa', 'fa-circle-plus', 'text-success'];
+          }
+          if (transaction.transaction_type === 'transfer') {
+            return ['fa', 'fa-exchange-alt', 'text-primary'];
+          }
+        }
+
+        if (typeConfig.category === 'investment') {
+          return ['fa', 'fa-line-chart', 'text-primary'];
+        }
+
+        return ['fa', 'fa-circle', 'text-muted'];
+      },
+      getTransactionById(id) {
+        const transactionId = Number(id);
+
+        return (
+          this.transactions.find(
+            (attribute) => Number(attribute.customData?.id) === transactionId,
+          )?.customData || null
+        );
+      },
+      getTransactionLabel(transaction) {
+        if (!transaction) {
+          return '';
+        }
+
+        if (transaction.config_type === 'standard') {
+          const type =
+            transaction.transaction_type.charAt(0).toUpperCase() +
+            transaction.transaction_type.slice(1);
+
+          return this.__('widget.scheduleCalendar.transactionLabel', {
+            type: __(type),
+            amount: toFormattedCurrency(
+              transaction.config.amount_to,
+              this.locale,
+              transaction.transaction_currency,
+            ),
+            fromAccount: transaction.config.account_from.name,
+            toAccount: transaction.config.account_to.name,
+          });
+        }
+
+        if (transaction.config_type === 'investment') {
+          const typeConfig = getTransactionTypeConfig(
+            transaction.transaction_type,
+          );
+          const investmentName = transaction.config?.investment?.name;
+          const accountName = transaction.config?.account?.name;
+          const quantity = transaction.config?.quantity;
+
+          let label = `${this.__(typeConfig.label)}: ${investmentName || this.__('N/A')}`;
+
+          if (accountName) {
+            label += `\n${this.__('Account')}: ${accountName}`;
+          }
+
+          if (quantity !== null && quantity !== undefined) {
+            label += `\n${this.__('Quantity')}: ${Number(quantity).toLocaleString(this.locale)}`;
+          }
+
+          return label;
+        }
+
+        return '';
+      },
+      getPopoverContent(transaction) {
+        const label = escapeHtmlWithLineBreaks(
+          this.getTransactionLabel(transaction),
+        );
+
+        return `
+      <div class="schedule-calendar-popover-content">
+        <div class="schedule-calendar-popover-label">${label}</div>
+        <div class="schedule-calendar-popover-actions">
+          <button
+            type="button"
+            class="btn btn-sm btn-warning"
+            data-schedule-calendar-action="skip"
+            data-transaction-id="${transaction.id}"
+            title="${escapeHtml(this.__('Skip schedule instance'))}"
+          >
+            <i class="fa fa-fw fa-fast-forward"></i>
+          </button>
+          <button
+            type="button"
+            class="btn btn-sm btn-success"
+            data-schedule-calendar-action="enter"
+            data-transaction-id="${transaction.id}"
+            title="${escapeHtml(this.__('Enter schedule instance'))}"
+          >
+            <i class="fa fa-fw fa-pencil"></i>
+          </button>
+        </div>
+      </div>
+    `;
+      },
+      clearPopoverHideTimer() {
+        if (!this.popoverHideTimer) {
+          return;
+        }
+
+        clearTimeout(this.popoverHideTimer);
+        this.popoverHideTimer = null;
+      },
+      schedulePopoverHide() {
+        this.clearPopoverHideTimer();
+        this.popoverHideTimer = setTimeout(() => {
+          this.hideActivePopover();
+        }, this.popoverHideDelayMs);
+      },
+      hideActivePopover() {
+        this.clearPopoverHideTimer();
+
+        if (!this.activePopover) {
+          return;
+        }
+
+        const tip = this.getPopoverTipElement();
+        if (tip) {
+          tip.removeEventListener('mouseenter', this.clearPopoverHideTimer);
+          tip.removeEventListener('mouseleave', this.schedulePopoverHide);
+        }
+
+        this.activePopover.hide();
+      },
+      disposeActivePopover() {
+        this.hideActivePopover();
+
+        if (!this.activePopover) {
+          return;
+        }
+
+        this.activePopover.dispose();
+        this.activePopover = null;
+        this.activePopoverTrigger = null;
+      },
+      showPopover(event, transaction) {
+        if (!event.currentTarget || !transaction) {
+          return;
+        }
+
+        const triggerElement = event.currentTarget;
+        const shouldRecreatePopover =
+          !this.activePopover || this.activePopoverTrigger !== triggerElement;
+
+        this.clearPopoverHideTimer();
+
+        if (shouldRecreatePopover) {
+          this.disposeActivePopover();
+
+          this.activePopover = new window.bootstrap.Popover(triggerElement, {
+            container: 'body',
+            content: this.getPopoverContent(transaction),
+            customClass: 'schedule-calendar-popover',
+            html: true,
+            placement: 'auto',
+            popperConfig(defaultBsPopperConfig) {
+              return {
+                ...defaultBsPopperConfig,
+                modifiers: [
+                  ...(defaultBsPopperConfig?.modifiers || []),
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [0, 12],
+                    },
+                  },
+                ],
+              };
+            },
+            sanitize: false,
+            trigger: 'manual',
+          });
+          this.activePopoverTrigger = triggerElement;
+        }
+
+        this.activePopover.show();
+
+        const tip = this.getPopoverTipElement();
+        if (tip) {
+          tip.addEventListener('mouseenter', this.clearPopoverHideTimer);
+          tip.addEventListener('mouseleave', this.schedulePopoverHide);
+        }
+      },
+      getPopoverTipElement() {
+        if (!this.activePopover) {
+          return null;
+        }
+
+        if (typeof this.activePopover.getTipElement === 'function') {
+          return this.activePopover.getTipElement();
+        }
+
+        return this.activePopover.tip || null;
+      },
+      onTransactionTriggerEnter(event, transaction) {
+        this.showPopover(event, transaction);
+      },
+      onTransactionTriggerLeave() {
+        this.schedulePopoverHide();
+      },
+      async skipInstance(transactionId, buttonElement = null) {
+        if (this.skipInstanceBusy) {
+          return;
+        }
+
+        this.skipInstanceBusy = true;
+        const id = Number(transactionId);
+        const originalButtonContent = buttonElement?.innerHTML || null;
+
+        try {
+          if (buttonElement) {
+            buttonElement.disabled = true;
+            buttonElement.innerHTML =
+              '<i class="fa fa-fw fa-spinner fa-spin"></i>';
+          }
+
+          await axios.patch(
+            this.route('api.v1.transactions.skip', {
+              transaction: id,
+            }),
+          );
+
+          toastHelpers.showSuccessToast(this.__('Schedule instance skipped.'));
+
+          this.hideActivePopover();
+          await this.loadTransactions();
+        } catch (error) {
+          toastHelpers.showErrorToast(
+            error?.response?.data?.message ||
+              error?.message ||
+              this.__('Error skipping schedule instance.'),
+          );
+        } finally {
+          if (buttonElement) {
+            buttonElement.disabled = false;
+            buttonElement.innerHTML = originalButtonContent;
+          }
+
+          this.skipInstanceBusy = false;
+        }
+      },
+      enterInstance(transactionId) {
+        const transaction = this.getTransactionById(transactionId);
+
+        if (!transaction) {
+          return;
+        }
+
+        const draft = {
+          ...transaction,
+          schedule: false,
+          budget: false,
+          date: transaction.transaction_schedule?.next_date,
+        };
+
+        const event = new CustomEvent('initiateEnterInstance', {
+          detail: {
+            transaction: draft,
+          },
+        });
+        window.dispatchEvent(event);
+
+        this.hideActivePopover();
+      },
+      onPopoverActionClick(event) {
+        const button = event.target.closest('[data-schedule-calendar-action]');
+        if (!button) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const action = button.dataset.scheduleCalendarAction;
+        const transactionId = Number(button.dataset.transactionId);
+
+        if (!transactionId) {
+          return;
+        }
+
+        if (action === 'skip') {
+          this.skipInstance(transactionId, button);
+          return;
+        }
+
+        if (action === 'enter') {
+          this.enterInstance(transactionId);
+        }
+      },
+      handlePagesUpdate(pages) {
+        if (!Array.isArray(pages) || pages.length === 0) {
+          return;
+        }
+
+        const firstPage = pages[0];
+        if (!firstPage?.month || !firstPage?.year) {
+          return;
+        }
+
+        this.visiblePage = {
+          month: firstPage.month,
+          year: firstPage.year,
+        };
+      },
+      async restoreVisiblePage() {
+        if (!this.visiblePage || !this.$refs.calendar?.move) {
+          return;
+        }
+
+        await this.$nextTick();
+
+        try {
+          await this.$refs.calendar.move(this.visiblePage, {
+            force: true,
+            position: 1,
+            transition: 'none',
+          });
+        } catch (_error) {
+          // Ignore failed page restoration when the requested page is no longer valid.
+        }
+      },
+      updateCalendarRange() {
+        if (this.transactions.length > 1) {
+          const minDate = this.transactions
+            .map((transaction) => transaction.dates)
+            .reduce(function (a, b) {
+              return a < b ? a : b;
+            });
+
+          this.minDate = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
+
+          const maxDate = this.transactions
+            .map((transaction) => transaction.dates)
+            .reduce(function (a, b) {
+              return a > b ? a : b;
+            });
+
+          this.maxDate = new Date(
+            maxDate.getFullYear(),
+            maxDate.getMonth() + 1,
+            0,
+          );
+          return;
+        }
+
+        if (this.transactions.length === 1) {
+          const date = new Date(this.transactions[0].dates);
+          this.minDate = new Date(date.getFullYear(), date.getMonth(), 1);
+          this.maxDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+          return;
+        }
+
+        const date = this.visiblePage
+          ? new Date(this.visiblePage.year, this.visiblePage.month - 1, 1)
+          : new Date();
+        this.minDate = new Date(date.getFullYear(), date.getMonth(), 1);
+        this.maxDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+      },
+      async loadTransactions() {
+        this.busy = true;
+        this.disposeActivePopover();
+
+        try {
+          const response = await axios.get(
+            '/api/v1/transactions/scheduled-items?type=schedule',
+          );
+
+          this.transactions = response.data.transactions
             .filter(
               (transaction) =>
                 transaction.transaction_schedule &&
                 transaction.transaction_schedule.next_date,
             )
-            // Map the data to the format required by the calendar component
             .map(function (transaction, index) {
               return {
                 key: index + 1,
@@ -160,47 +521,24 @@
               };
             });
 
-          // Set min and max dates or fall back to current month
-          if (vue.transactions.length > 1) {
-            const minDate = vue.transactions
-              .map((transaction) => transaction.dates)
-              .reduce(function (a, b) {
-                return a < b ? a : b;
-              });
-
-            // Set the minDate to the first day of the same month
-            vue.minDate = new Date(
-              minDate.getFullYear(),
-              minDate.getMonth(),
-              1,
-            );
-
-            const maxDate = vue.transactions
-              .map((transaction) => transaction.dates)
-              .reduce(function (a, b) {
-                return a > b ? a : b;
-              });
-
-            // Set the maxDate to the last day of the same month
-            vue.maxDate = new Date(
-              maxDate.getFullYear(),
-              maxDate.getMonth() + 1,
-              0,
-            );
-          } else if (vue.transactions.length === 1) {
-            const date = new Date(vue.transactions[0].dates);
-            vue.minDate = new Date(date.getFullYear(), date.getMonth(), 1);
-            vue.maxDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-          } else {
-            const date = new Date();
-            vue.minDate = new Date(date.getFullYear(), date.getMonth(), 1);
-            vue.maxDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-          }
-        })
-        .finally(function () {
-          vue.busy = false;
-          setTimeout(() => vue.refreshTooltip(), 1000);
-        });
+          this.updateCalendarRange();
+          await this.restoreVisiblePage();
+        } finally {
+          this.busy = false;
+        }
+      },
+      handleTransactionCreated() {
+        this.loadTransactions();
+      },
+      onCalendarTransitionStart() {
+        this.disposeActivePopover();
+      },
+      __,
+      toFormattedCurrency,
+      hide() {
+        this.disposeActivePopover();
+        $('#widgetScheduleCalendar').hide();
+      },
     },
   };
 </script>
@@ -237,5 +575,77 @@
 
   .custom-calendar .vc-day-custom-content {
     line-height: normal;
+  }
+
+  .schedule-calendar-trigger {
+    margin: 0 1px;
+    text-decoration: none;
+  }
+
+  .schedule-calendar-trigger:focus {
+    box-shadow: none;
+  }
+
+  .schedule-calendar-popover {
+    --bs-popover-bg: #1f2937;
+    --bs-popover-body-bg: #1f2937;
+    --bs-popover-border-color: transparent;
+    --bs-popover-arrow-border: transparent;
+    --cui-popover-bg: #1f2937;
+    --cui-popover-body-bg: #1f2937;
+    --cui-popover-border-color: transparent;
+    --cui-popover-arrow-border: transparent;
+    background-color: transparent;
+  }
+
+  .popover.schedule-calendar-popover {
+    background-color: #1f2937;
+    border-color: transparent;
+  }
+
+  .schedule-calendar-popover .popover-body {
+    min-width: 230px;
+    background-color: #1f2937;
+    color: #f8fafc;
+  }
+
+  .schedule-calendar-popover .popover-arrow::before {
+    display: none;
+  }
+
+  .popover.schedule-calendar-popover[data-popper-placement^='top']
+    > .popover-arrow::after {
+    border-top-color: #1f2937;
+  }
+
+  .popover.schedule-calendar-popover[data-popper-placement^='bottom']
+    > .popover-arrow::after {
+    border-bottom-color: #1f2937;
+  }
+
+  .popover.schedule-calendar-popover[data-popper-placement^='left']
+    > .popover-arrow::after {
+    border-left-color: #1f2937;
+  }
+
+  .popover.schedule-calendar-popover[data-popper-placement^='right']
+    > .popover-arrow::after {
+    border-right-color: #1f2937;
+  }
+
+  .schedule-calendar-popover-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .schedule-calendar-popover-label {
+    white-space: normal;
+  }
+
+  .schedule-calendar-popover-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
   }
 </style>

--- a/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
+++ b/resources/js/dashboard/components/widgets/ScheduleCalendar.vue
@@ -95,7 +95,7 @@
         activePopover: null,
         activePopoverTrigger: null,
         popoverHideTimer: null,
-        popoverHideDelayMs: 1000,
+        popoverHideDelayMs: 1500,
         skipInstanceBusy: false,
         visiblePage: null,
       };
@@ -109,12 +109,7 @@
       );
     },
 
-    mounted() {
-      document.addEventListener('click', this.onPopoverActionClick);
-    },
-
     beforeUnmount() {
-      document.removeEventListener('click', this.onPopoverActionClick);
       window.removeEventListener(
         'transaction-created',
         this.handleTransactionCreated,
@@ -145,7 +140,7 @@
         }
 
         if (typeConfig.category === 'investment') {
-          return ['fa', 'fa-line-chart', 'text-primary'];
+          return ['fa', 'fa-chart-line', 'text-primary'];
         }
 
         return ['fa', 'fa-circle', 'text-muted'];
@@ -211,6 +206,15 @@
 
         return `
       <div class="schedule-calendar-popover-content">
+        <div class="schedule-calendar-popover-header">
+          <button
+            type="button"
+            class="btn-close btn-close-white schedule-calendar-popover-close"
+            data-schedule-calendar-action="close"
+            title="${escapeHtml(this.__('Close'))}"
+            aria-label="${escapeHtml(this.__('Close'))}"
+          ></button>
+        </div>
         <div class="schedule-calendar-popover-label">${label}</div>
         <div class="schedule-calendar-popover-actions">
           <button
@@ -258,8 +262,11 @@
 
         const tip = this.getPopoverTipElement();
         if (tip) {
+          tip.removeEventListener('click', this.onPopoverActionClick);
           tip.removeEventListener('mouseenter', this.clearPopoverHideTimer);
           tip.removeEventListener('mouseleave', this.schedulePopoverHide);
+          tip.removeEventListener('focusin', this.clearPopoverHideTimer);
+          tip.removeEventListener('focusout', this.schedulePopoverHide);
         }
 
         this.activePopover.hide();
@@ -294,7 +301,8 @@
             content: this.getPopoverContent(transaction),
             customClass: 'schedule-calendar-popover',
             html: true,
-            placement: 'auto',
+            placement: 'top',
+            fallbackPlacements: ['top', 'right', 'left', 'bottom'],
             popperConfig(defaultBsPopperConfig) {
               return {
                 ...defaultBsPopperConfig,
@@ -303,7 +311,7 @@
                   {
                     name: 'offset',
                     options: {
-                      offset: [0, 12],
+                      offset: [0, 8],
                     },
                   },
                 ],
@@ -319,8 +327,11 @@
 
         const tip = this.getPopoverTipElement();
         if (tip) {
+          tip.addEventListener('click', this.onPopoverActionClick);
           tip.addEventListener('mouseenter', this.clearPopoverHideTimer);
           tip.addEventListener('mouseleave', this.schedulePopoverHide);
+          tip.addEventListener('focusin', this.clearPopoverHideTimer);
+          tip.addEventListener('focusout', this.schedulePopoverHide);
         }
       },
       getPopoverTipElement() {
@@ -405,8 +416,17 @@
         this.hideActivePopover();
       },
       onPopoverActionClick(event) {
+        if (!(event.target instanceof Element)) {
+          return;
+        }
+
         const button = event.target.closest('[data-schedule-calendar-action]');
         if (!button) {
+          return;
+        }
+
+        const tip = this.getPopoverTipElement();
+        if (!tip || !tip.contains(button)) {
           return;
         }
 
@@ -414,6 +434,12 @@
         event.stopPropagation();
 
         const action = button.dataset.scheduleCalendarAction;
+
+        if (action === 'close') {
+          this.hideActivePopover();
+          return;
+        }
+
         const transactionId = Number(button.dataset.transactionId);
 
         if (!transactionId) {
@@ -583,6 +609,8 @@
   }
 
   .schedule-calendar-trigger:focus {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
     box-shadow: none;
   }
 
@@ -637,6 +665,21 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  .schedule-calendar-popover-header {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .schedule-calendar-popover-close {
+    transform: scale(0.82);
+    transform-origin: top right;
+    opacity: 0.65;
+  }
+
+  .schedule-calendar-popover-close:hover {
+    opacity: 0.85;
   }
 
   .schedule-calendar-popover-label {

--- a/resources/js/dashboard/index.js
+++ b/resources/js/dashboard/index.js
@@ -1,12 +1,20 @@
-import { createApp } from 'vue'
+import { createApp } from 'vue';
 import { installRouteGlobal } from '@/shared/lib/vue/installRouteGlobal';
-const app = createApp({})
+const app = createApp({});
 
 // Add global translator function
 app.config.globalProperties.__ = window.__;
 installRouteGlobal(app);
 
-import Dashboard from './components/Dashboard.vue'
-app.component('dashboard', Dashboard)
+import Dashboard from './components/Dashboard.vue';
+import CreateStandardTransactionModal from '@/transactions/components/form/ModalStandard.vue';
+import CreateInvestmentTransactionModal from '@/transactions/components/form/ModalInvestment.vue';
 
-app.mount('#app')
+app.component('dashboard', Dashboard);
+app.component('transaction-create-standard-modal', CreateStandardTransactionModal);
+app.component(
+  'transaction-create-investment-modal',
+  CreateInvestmentTransactionModal,
+);
+
+app.mount('#app');

--- a/resources/views/pages/dashboard.blade.php
+++ b/resources/views/pages/dashboard.blade.php
@@ -9,5 +9,7 @@
 @section('content')
     <div id="app">
         <dashboard></dashboard>
+        <transaction-create-standard-modal></transaction-create-standard-modal>
+        <transaction-create-investment-modal></transaction-create-investment-modal>
     </div>
 @stop


### PR DESCRIPTION
Improves the usability of the schedule calendar widget by allowing users to act on upcoming scheduled transactions directly.

*   Introduces an interactive popover that appears when hovering or focusing on a scheduled transaction in the calendar.
*   Adds "Skip" and "Enter" actions within the popover, allowing users to either skip the next instance of a schedule or initiate the transaction entry workflow via a modal.
*   Ensures the calendar preserves the currently visible month when data refreshes after an action, providing a smoother user experience.
*   Enhances transaction type icons and labels to be more informative, including support for investment transactions.
*   Integrates transaction creation modals into the dashboard to support the new "enter instance" action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Interactive per-item popovers on the schedule calendar (hover/focus/click) with skip and enter actions; buttons show busy state and toasts for results
  * Investment transactions display richer multi-line details (name, account, quantity)
  * Popovers close when moving the calendar; visible month is preserved after actions and refreshes

* **New Features**
  * Dashboard now includes modals for creating standard and investment transactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->