### PR TITLE
Add advanced account reconciliation, This adds the interface to the a…

### DIFF
--- a/.ai/agents/frontend.agent.md
+++ b/.ai/agents/frontend.agent.md
@@ -79,6 +79,9 @@ If API behavior or UI requirements are unclear, STOP and ask for clarification.
 - Display server-side validation errors clearly
 - Do NOT duplicate complex backend validation logic
 - Handle network and authorization errors gracefully
+- Native `fetch` does not reject for HTTP 4xx/5xx responses; check `response.ok` before rendering successful data
+- Prefer shared escaping helpers for any value interpolated into HTML strings, including attribute values
+- When handling Axios failures, prefer Laravel's `error.response?.data?.message` before falling back to `error.message`
 
 ---
 

--- a/.ai/agents/laravel-backend.agent.md
+++ b/.ai/agents/laravel-backend.agent.md
@@ -52,6 +52,13 @@ If something is unclear or missing, STOP and ask for clarification.
 - Use Form Requests for validation
 - Keep Eloquent relationships explicit
 - Avoid magic attributes unless already used
+- Keep controllers thin: validate with Form Requests, authorize, delegate to Services, and return responses
+- Put persistence that encodes feature behavior in Services rather than controllers
+- Prefer `Model::query()` / Eloquent entry points over `DB::table()` for application queries
+- Compare `date` columns with date strings (`toDateString()`) rather than Carbon datetime instances when the column is date-only
+- Capture time-dependent values such as `now()` once before loops to avoid boundary inconsistencies
+- Scope unique indexes to the owning domain entity when imported/source identifiers can repeat across accounts or users
+- Centralize repeated domain string sets in enums when the codebase already has enum conventions
 
 ---
 
@@ -61,6 +68,7 @@ If something is unclear or missing, STOP and ask for clarification.
 - Type hints where reasonable
 - Clear method and variable names
 - Small, composable methods
+- Array return PHPDoc should use array shapes for structured service payloads
 - Use database transactions where consistency matters
 - Handle failure paths explicitly
 

--- a/.ai/agents/testing.agent.md
+++ b/.ai/agents/testing.agent.md
@@ -49,6 +49,7 @@ If test intent is unclear, STOP and ask for clarification.
 - Use database transactions or refreshes
 - Assert validation, authorization, and responses
 - Cover both success and failure paths
+- For Form Request-backed endpoints, include validation failure cases for required fields, invalid enum values, and malformed dates or numbers
 
 ### Laravel Dusk Tests
 

--- a/.ai/docs/advanced-reconcile.md
+++ b/.ai/docs/advanced-reconcile.md
@@ -30,7 +30,7 @@ Checkpoint records are stored in `account_balance_checkpoints`.
 - `checkpoint_type` is one of `cash`, `investment`, or `total`.
 - `checkpoint_date` represents the statement/checkpoint date.
 - Multiple manual checkpoints are allowed; the latest active checkpoint for the same account, type, and date is used on the account page.
-- Source document uniqueness is reserved for document-imported checkpoints with `source` and `source_document_id`.
+- Source document uniqueness is reserved for document-imported checkpoints and is scoped by account, `source`, and `source_document_id` so different accounts can reference the same external document identifier.
 
 ## Dashboard
 

--- a/.ai/docs/advanced-reconcile.md
+++ b/.ai/docs/advanced-reconcile.md
@@ -1,0 +1,50 @@
+# Advanced Reconcile
+
+Advanced Reconcile adds statement-style reconciliation for account cash, investment value, and total account value.
+
+## Account Page
+
+The account detail page includes a collapsed Advanced Reconcile panel above transaction history. It uses the page date filter as the reconciliation period.
+
+- Cash compares opening cash balance, period withdrawals, period deposits, and closing cash balance.
+- Investment compares opening market value and closing market value.
+- Total compares cash plus investment value.
+- Each section can save a checkpoint value and note for the period end date.
+- Investment holdings list positions with non-zero opening quantity, closing quantity, buys, or sells in the period.
+- Missing investment prices are treated as zero for valuation and flagged for user entry.
+- Opening and closing price cells are clickable. Users can save a price directly, or enter the statement value of the holding and let Yaffa derive the unit price from the quantity held at that date.
+
+## Investment Price Entry
+
+The investment holdings price modal has two modes:
+
+- `Price at date` stores the entered unit price for the opening or closing statement date.
+- `Value at date` divides the entered holding value by the opening or closing quantity and stores the derived unit price for that statement date.
+
+If a stored investment price already exists on the exact statement date, saving from the modal updates that price. If the displayed price came from an earlier stored price or a transaction price, saving creates a new stored price on the statement date.
+
+## Checkpoints
+
+Checkpoint records are stored in `account_balance_checkpoints`.
+
+- `checkpoint_type` is one of `cash`, `investment`, or `total`.
+- `checkpoint_date` represents the statement/checkpoint date.
+- Multiple manual checkpoints are allowed; the latest active checkpoint for the same account, type, and date is used on the account page.
+- Source document uniqueness is reserved for document-imported checkpoints with `source` and `source_document_id`.
+
+## Dashboard
+
+The Advanced Reconcile report shows active accounts down the left and the latest 12 calendar months across the top, newest first.
+
+- The report can be filtered by checkpoint type.
+- The display can show status or saved checkpoint balance.
+- Statuses are `Matched`, `Reconcile required`, and `No checkpoint`.
+- Reconcile required cells include the variance and link to the account page with date parameters.
+
+## Current Assumptions
+
+- Cash balance uses the same ledger semantics as Yaffa account balances: standard account movements plus investment transaction cashflows.
+- Investment value uses quantity held multiplied by the latest known combined price on or before the target date.
+- Total is cash plus investment value.
+- Dashboard month assignment uses the latest active checkpoint whose checkpoint date falls inside that calendar month.
+- Dashboard variance compares the checkpoint value to the calculated balance on the checkpoint date.

--- a/.ai/docs/assets/account/overview.md
+++ b/.ai/docs/assets/account/overview.md
@@ -78,6 +78,7 @@ The `account.history` route (`MainController::account_details`) loads all transa
 - **Currency** — must be one of the user's own currencies (pre-condition: at least one currency must exist)
 - **Import alias** — optional free-text field; newline-separated values matched against AI document processing account strings
 - **Default date range** — optional preset controlling how far back the account detail view loads by default; overrides the global user setting if set; can also be set to "Don't load data by default"
+- **Checkpoint window presets** — on account details, saved reconciliation checkpoints can add dynamic date preset options. Each window runs from the previous checkpoint date plus one day through the selected checkpoint date.
 
 ### System inputs:
 

--- a/app/Enums/CheckpointType.php
+++ b/app/Enums/CheckpointType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum CheckpointType: string
+{
+    case CASH = 'cash';
+    case INVESTMENT = 'investment';
+    case TOTAL = 'total';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $type): string => $type->value, self::cases());
+    }
+}

--- a/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
+++ b/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AccountBalanceCheckpointRequest;
+use App\Models\AccountBalanceCheckpoint;
+use App\Models\AccountEntity;
+use App\Services\AdvancedReconcileService;
+use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Support\Facades\Gate;
+
+class AccountBalanceCheckpointApiController extends Controller implements HasMiddleware
+{
+    public function __construct(
+        private readonly AdvancedReconcileService $advancedReconcileService,
+    ) {
+    }
+
+    public static function middleware(): array
+    {
+        return [
+            'auth:sanctum',
+            'verified',
+        ];
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function accountSummary(Request $request, AccountEntity $accountEntity): JsonResponse
+    {
+        Gate::authorize('view', $accountEntity);
+
+        if (!$accountEntity->isAccount()) {
+            return response()->json([
+                'message' => __('This account entity is not an account.'),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $validated = $request->validate([
+            'date_from' => ['nullable', 'date'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+        ]);
+
+        $dateTo = Carbon::parse($validated['date_to'] ?? now()->toDateString())->startOfDay();
+        $dateFrom = Carbon::parse($validated['date_from'] ?? $dateTo->copy()->startOfMonth()->toDateString())->startOfDay();
+
+        return response()->json(
+            $this->advancedReconcileService->accountSummary($accountEntity, $dateFrom, $dateTo),
+            Response::HTTP_OK
+        );
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function store(AccountBalanceCheckpointRequest $request, AccountEntity $accountEntity): JsonResponse
+    {
+        Gate::authorize('update', $accountEntity);
+
+        if (!$accountEntity->isAccount()) {
+            return response()->json([
+                'message' => __('This account entity is not an account.'),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $validated = $request->validated();
+
+        $checkpoint = AccountBalanceCheckpoint::create([
+            'user_id' => $request->user()->id,
+            'account_entity_id' => $accountEntity->id,
+            'checkpoint_date' => $validated['checkpoint_date'],
+            'checkpoint_type' => $validated['checkpoint_type'],
+            'balance' => $validated['balance'],
+            'note' => $validated['note'] ?? null,
+            'active' => true,
+            'source' => $validated['source'] ?? 'manual',
+            'source_document_id' => $validated['source_document_id'] ?? null,
+        ]);
+
+        return response()->json([
+            'checkpoint' => $checkpoint,
+            'message' => __('Checkpoint saved'),
+        ], Response::HTTP_CREATED);
+    }
+
+    public function dashboard(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'checkpoint_type' => ['nullable', 'in:cash,investment,total'],
+            'display' => ['nullable', 'in:status,balance'],
+        ]);
+
+        $checkpointType = $validated['checkpoint_type'] ?? 'total';
+
+        $months = collect(range(0, 11))
+            ->map(fn (int $offset): Carbon => now()->startOfMonth()->subMonths($offset));
+
+        $accounts = $request->user()
+            ->accounts()
+            ->active()
+            ->with(['config', 'config.currency'])
+            ->orderBy('name')
+            ->get();
+
+        $rows = $accounts->map(fn (AccountEntity $accountEntity): array => [
+            'account' => [
+                'id' => $accountEntity->id,
+                'name' => $accountEntity->name,
+                'currency' => $accountEntity->config->currency ?? null,
+            ],
+            'months' => $months->mapWithKeys(fn (Carbon $month): array => [
+                $month->format('Y-m') => $this->advancedReconcileService->dashboard($accountEntity, $month, $checkpointType),
+            ]),
+        ]);
+
+        return response()->json([
+            'checkpoint_type' => $checkpointType,
+            'display' => $validated['display'] ?? 'status',
+            'months' => $months->map(fn (Carbon $month): array => [
+                'key' => $month->format('Y-m'),
+                'label' => $month->format('M Y'),
+            ])->values(),
+            'rows' => $rows,
+        ], Response::HTTP_OK);
+    }
+}

--- a/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
+++ b/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
@@ -2,15 +2,16 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Enums\CheckpointType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccountBalanceCheckpointRequest;
-use App\Models\AccountBalanceCheckpoint;
+use App\Http\Requests\AccountSummaryRequest;
+use App\Http\Requests\AdvancedReconcileDashboardRequest;
 use App\Models\AccountEntity;
 use App\Services\AdvancedReconcileService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Support\Facades\Gate;
@@ -33,7 +34,7 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
     /**
      * @throws AuthorizationException
      */
-    public function accountSummary(Request $request, AccountEntity $accountEntity): JsonResponse
+    public function accountSummary(AccountSummaryRequest $request, AccountEntity $accountEntity): JsonResponse
     {
         Gate::authorize('view', $accountEntity);
 
@@ -43,10 +44,7 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $validated = $request->validate([
-            'date_from' => ['nullable', 'date'],
-            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
-        ]);
+        $validated = $request->validated();
 
         $dateTo = Carbon::parse($validated['date_to'] ?? now()->toDateString())->startOfDay();
         $dateFrom = Carbon::parse($validated['date_from'] ?? $dateTo->copy()->startOfMonth()->toDateString())->startOfDay();
@@ -70,19 +68,11 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $validated = $request->validated();
-
-        $checkpoint = AccountBalanceCheckpoint::create([
-            'user_id' => $request->user()->id,
-            'account_entity_id' => $accountEntity->id,
-            'checkpoint_date' => $validated['checkpoint_date'],
-            'checkpoint_type' => $validated['checkpoint_type'],
-            'balance' => $validated['balance'],
-            'note' => $validated['note'] ?? null,
-            'active' => true,
-            'source' => $validated['source'] ?? 'manual',
-            'source_document_id' => $validated['source_document_id'] ?? null,
-        ]);
+        $checkpoint = $this->advancedReconcileService->storeCheckpoint(
+            $request->user(),
+            $accountEntity,
+            $request->validated()
+        );
 
         return response()->json([
             'checkpoint' => $checkpoint,
@@ -90,17 +80,14 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
         ], Response::HTTP_CREATED);
     }
 
-    public function dashboard(Request $request): JsonResponse
+    public function dashboard(AdvancedReconcileDashboardRequest $request): JsonResponse
     {
-        $validated = $request->validate([
-            'checkpoint_type' => ['nullable', 'in:cash,investment,total'],
-            'display' => ['nullable', 'in:status,balance'],
-        ]);
+        $validated = $request->validated();
+        $checkpointType = CheckpointType::from($validated['checkpoint_type'] ?? CheckpointType::TOTAL->value);
 
-        $checkpointType = $validated['checkpoint_type'] ?? 'total';
-
+        $now = now();
         $months = collect(range(0, 11))
-            ->map(fn (int $offset): Carbon => now()->startOfMonth()->subMonths($offset));
+            ->map(fn (int $offset): Carbon => $now->copy()->startOfMonth()->subMonths($offset));
 
         $accounts = $request->user()
             ->accounts()
@@ -121,7 +108,7 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
         ]);
 
         return response()->json([
-            'checkpoint_type' => $checkpointType,
+            'checkpoint_type' => $checkpointType->value,
             'display' => $validated['display'] ?? 'status',
             'months' => $months->map(fn (Carbon $month): array => [
                 'key' => $month->format('Y-m'),

--- a/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
+++ b/app/Http/Controllers/API/AccountBalanceCheckpointApiController.php
@@ -100,7 +100,7 @@ class AccountBalanceCheckpointApiController extends Controller implements HasMid
             'account' => [
                 'id' => $accountEntity->id,
                 'name' => $accountEntity->name,
-                'currency' => $accountEntity->config->currency ?? null,
+                'currency' => $accountEntity->config?->currency,
             ],
             'months' => $months->mapWithKeys(fn (Carbon $month): array => [
                 $month->format('Y-m') => $this->advancedReconcileService->dashboard($accountEntity, $month, $checkpointType),

--- a/app/Http/Controllers/AccountEntityController.php
+++ b/app/Http/Controllers/AccountEntityController.php
@@ -11,6 +11,7 @@ use App\Models\AccountEntity;
 use App\Models\Category;
 use App\Services\PayeeCategoryStatsService;
 use App\Services\PayeePersistenceService;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -84,6 +85,7 @@ class AccountEntityController extends Controller implements HasMiddleware
             JavaScriptFacade::put([
                 'account' => $accountEntity,
                 'filters' => $filters,
+                'checkpointWindows' => $this->checkpointWindowsForAccount($accountEntity),
             ]);
 
             return view(
@@ -96,6 +98,37 @@ class AccountEntityController extends Controller implements HasMiddleware
 
         // Currently no function for Payees, redirect back
         return redirect()->back();
+    }
+
+    /**
+     * @return list<array{value: string, label: string, date_from: string, date_to: string}>
+     */
+    private function checkpointWindowsForAccount(AccountEntity $accountEntity): array
+    {
+        $checkpointDates = $accountEntity->balanceCheckpoints()
+            ->where('active', true)
+            ->orderBy('checkpoint_date')
+            ->pluck('checkpoint_date')
+            ->map(fn ($date): string => Carbon::parse($date)->toDateString())
+            ->unique()
+            ->values();
+
+        return $checkpointDates
+            ->skip(1)
+            ->map(function (string $checkpointDate, int $index) use ($checkpointDates): array {
+                $dateFrom = Carbon::parse($checkpointDates->get($index - 1))
+                    ->addDay()
+                    ->toDateString();
+
+                return [
+                    'value' => 'checkpointWindow:' . $checkpointDate,
+                    'label' => $dateFrom . ' - ' . $checkpointDate,
+                    'date_from' => $dateFrom,
+                    'date_to' => $checkpointDate,
+                ];
+            })
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -57,6 +57,16 @@ class ReportController extends Controller implements HasMiddleware
         return view('reports.budgetchart');
     }
 
+    public function advancedReconcile(Request $request): View
+    {
+        /**
+         * @get("/reports/advanced-reconcile")
+         * @name("reports.advanced-reconcile")
+         * @middlewares("web", "auth", "verified")
+         */
+        return view('reports.advanced-reconcile');
+    }
+
     /**
      * Display form for searching transactions.
      */

--- a/app/Http/Requests/AccountBalanceCheckpointRequest.php
+++ b/app/Http/Requests/AccountBalanceCheckpointRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Validation\Rule;
+
+class AccountBalanceCheckpointRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'checkpoint_date' => ['required', 'date'],
+            'checkpoint_type' => ['required', Rule::in(['cash', 'investment', 'total'])],
+            'balance' => ['required', 'numeric', 'min:-9999999999999.99', 'max:9999999999999.99'],
+            'note' => ['nullable', 'string'],
+            'source' => ['nullable', 'string', 'max:191'],
+            'source_document_id' => ['nullable', 'string', 'max:191'],
+        ];
+    }
+}

--- a/app/Http/Requests/AccountBalanceCheckpointRequest.php
+++ b/app/Http/Requests/AccountBalanceCheckpointRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\CheckpointType;
 use Illuminate\Validation\Rule;
 
 class AccountBalanceCheckpointRequest extends FormRequest
@@ -13,7 +14,7 @@ class AccountBalanceCheckpointRequest extends FormRequest
     {
         return [
             'checkpoint_date' => ['required', 'date'],
-            'checkpoint_type' => ['required', Rule::in(['cash', 'investment', 'total'])],
+            'checkpoint_type' => ['required', Rule::in(CheckpointType::values())],
             'balance' => ['required', 'numeric', 'min:-9999999999999.99', 'max:9999999999999.99'],
             'note' => ['nullable', 'string'],
             'source' => ['nullable', 'string', 'max:191'],

--- a/app/Http/Requests/AccountSummaryRequest.php
+++ b/app/Http/Requests/AccountSummaryRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+class AccountSummaryRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'date_from' => ['nullable', 'date'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+        ];
+    }
+}

--- a/app/Http/Requests/AdvancedReconcileDashboardRequest.php
+++ b/app/Http/Requests/AdvancedReconcileDashboardRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\CheckpointType;
+use Illuminate\Validation\Rule;
+
+class AdvancedReconcileDashboardRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'checkpoint_type' => ['nullable', Rule::in(CheckpointType::values())],
+            'display' => ['nullable', Rule::in(['status', 'balance'])],
+        ];
+    }
+}

--- a/app/Models/AccountBalanceCheckpoint.php
+++ b/app/Models/AccountBalanceCheckpoint.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\AccountBalanceCheckpointFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $account_entity_id
+ * @property \Illuminate\Support\Carbon $checkpoint_date
+ * @property string $checkpoint_type
+ * @property float $balance
+ * @property string|null $note
+ * @property bool $active
+ * @property string $source
+ * @property string|null $source_document_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read AccountEntity $accountEntity
+ * @property-read User $user
+ * @method static AccountBalanceCheckpointFactory factory($count = null, $state = [])
+ * @mixin \Eloquent
+ */
+class AccountBalanceCheckpoint extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'account_entity_id',
+        'checkpoint_date',
+        'checkpoint_type',
+        'balance',
+        'note',
+        'active',
+        'source',
+        'source_document_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'checkpoint_date' => 'date',
+            'balance' => 'float',
+            'active' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function accountEntity(): BelongsTo
+    {
+        return $this->belongsTo(AccountEntity::class);
+    }
+}

--- a/app/Models/AccountBalanceCheckpoint.php
+++ b/app/Models/AccountBalanceCheckpoint.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\CheckpointType;
 use Database\Factories\AccountBalanceCheckpointFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $user_id
  * @property int $account_entity_id
  * @property \Illuminate\Support\Carbon $checkpoint_date
- * @property string $checkpoint_type
+ * @property CheckpointType $checkpoint_type
  * @property float $balance
  * @property string|null $note
  * @property bool $active
@@ -45,6 +46,7 @@ class AccountBalanceCheckpoint extends Model
     {
         return [
             'checkpoint_date' => 'date',
+            'checkpoint_type' => CheckpointType::class,
             'balance' => 'float',
             'active' => 'boolean',
         ];

--- a/app/Models/AccountEntity.php
+++ b/app/Models/AccountEntity.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
 
@@ -114,6 +115,11 @@ class AccountEntity extends Model
                 'config_type',
                 'investment'
             );
+    }
+
+    public function balanceCheckpoints(): HasMany
+    {
+        return $this->hasMany(AccountBalanceCheckpoint::class);
     }
 
     public function transactionsStandardFrom(): HasManyThrough

--- a/app/Services/AdvancedReconcileService.php
+++ b/app/Services/AdvancedReconcileService.php
@@ -225,15 +225,16 @@ class AdvancedReconcileService
     private function investmentValueAt(AccountEntity $accountEntity, Carbon $date): array
     {
         $quantities = $this->quantitiesAt($accountEntity, $date);
+        $investments = Investment::whereIn('id', $quantities->pluck('investment_id'))->get()->keyBy('id');
         $missingPriceCount = 0;
 
-        $value = $quantities->sum(function (object $item) use ($date, &$missingPriceCount): float {
+        $value = $quantities->sum(function (object $item) use ($date, $investments, &$missingPriceCount): float {
             $quantity = (float) $item->quantity;
             if ($quantity === 0.0) {
                 return 0.0;
             }
 
-            $investment = Investment::find($item->investment_id);
+            $investment = $investments->get($item->investment_id);
             if ($investment === null) {
                 return 0.0;
             }

--- a/app/Services/AdvancedReconcileService.php
+++ b/app/Services/AdvancedReconcileService.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TransactionType as TransactionTypeEnum;
+use App\Models\Account;
+use App\Models\AccountBalanceCheckpoint;
+use App\Models\AccountEntity;
+use App\Models\Investment;
+use App\Models\InvestmentPrice;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class AdvancedReconcileService
+{
+    public function __construct(
+        private readonly InvestmentService $investmentService,
+    ) {
+    }
+
+    /**
+     * Build the reconciliation payload for one account and period.
+     *
+     * @return array<string, mixed>
+     */
+    public function accountSummary(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): array
+    {
+        $accountEntity->loadMissing(['config', 'config.currency']);
+
+        $cash = $this->cashSection($accountEntity, $dateFrom, $dateTo);
+        $investments = $this->investmentSection($accountEntity, $dateFrom, $dateTo);
+        $total = $this->totalSection($accountEntity, $dateTo, $cash, $investments);
+
+        return [
+            'date_from' => $dateFrom->toDateString(),
+            'date_to' => $dateTo->toDateString(),
+            'currency' => $accountEntity->config instanceof Account ? $accountEntity->config->currency : null,
+            'cash' => $cash,
+            'investment' => $investments,
+            'total' => $total,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function dashboard(AccountEntity $accountEntity, Carbon $month, string $checkpointType): array
+    {
+        $checkpoint = AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
+            ->where('checkpoint_type', $checkpointType)
+            ->where('active', true)
+            ->whereBetween('checkpoint_date', [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()])
+            ->latest('checkpoint_date')
+            ->latest('id')
+            ->first();
+
+        if ($checkpoint === null) {
+            return [
+                'status' => 'no_checkpoint',
+                'checkpoint' => null,
+                'calculated_balance' => null,
+                'variance' => null,
+                'date_from' => $month->copy()->startOfMonth()->toDateString(),
+                'date_to' => $month->copy()->endOfMonth()->toDateString(),
+            ];
+        }
+
+        $previousCheckpointDate = AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
+            ->where('checkpoint_type', $checkpointType)
+            ->where('active', true)
+            ->where('checkpoint_date', '<', $checkpoint->checkpoint_date)
+            ->latest('checkpoint_date')
+            ->value('checkpoint_date');
+
+        $dateFrom = $previousCheckpointDate === null
+            ? $checkpoint->checkpoint_date->copy()->startOfMonth()
+            : Carbon::parse($previousCheckpointDate)->addDay();
+
+        $calculatedBalance = $this->calculatedBalanceAt($accountEntity, $checkpoint->checkpoint_date, $checkpointType);
+        $variance = round($checkpoint->balance - $calculatedBalance, 2);
+
+        return [
+            'status' => abs($variance) < 0.01 ? 'matched' : 'reconcile_required',
+            'checkpoint' => $checkpoint,
+            'calculated_balance' => $calculatedBalance,
+            'variance' => $variance,
+            'date_from' => $dateFrom->toDateString(),
+            'date_to' => $checkpoint->checkpoint_date->toDateString(),
+        ];
+    }
+
+    public function calculatedBalanceAt(AccountEntity $accountEntity, Carbon $date, string $checkpointType): float
+    {
+        $cashBalance = $this->cashBalanceAt($accountEntity, $date);
+
+        if ($checkpointType === 'cash') {
+            return $cashBalance;
+        }
+
+        $investmentBalance = $this->investmentValueAt($accountEntity, $date)['value'];
+
+        if ($checkpointType === 'investment') {
+            return $investmentBalance;
+        }
+
+        return round($cashBalance + $investmentBalance, 2);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cashSection(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): array
+    {
+        $openingBalance = $this->cashBalanceBefore($accountEntity, $dateFrom);
+        $movements = $this->cashMovements($accountEntity, $dateFrom, $dateTo);
+
+        $totalDeposits = round($movements->filter(fn (float $amount): bool => $amount > 0)->sum(), 2);
+        $totalWithdrawals = round(abs($movements->filter(fn (float $amount): bool => $amount < 0)->sum()), 2);
+        $balance = round($openingBalance + $totalDeposits - $totalWithdrawals, 2);
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'cash');
+
+        return $this->withCheckpointState([
+            'opening_balance' => $openingBalance,
+            'total_withdrawals' => $totalWithdrawals,
+            'total_deposits' => $totalDeposits,
+            'balance' => $balance,
+        ], $checkpoint, $balance);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function investmentSection(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): array
+    {
+        $opening = $this->investmentValueAt($accountEntity, $dateFrom->copy()->subDay());
+        $closing = $this->investmentValueAt($accountEntity, $dateTo);
+        $holdings = $this->investmentHoldings($accountEntity, $dateFrom, $dateTo);
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'investment');
+
+        return $this->withCheckpointState([
+            'opening_value' => $opening['value'],
+            'closing_value' => $closing['value'],
+            'balance' => $closing['value'],
+            'holdings' => $holdings,
+            'missing_price_count' => collect($holdings)->where('has_missing_price', true)->count(),
+        ], $checkpoint, $closing['value']);
+    }
+
+    /**
+     * @param array<string, mixed> $cash
+     * @param array<string, mixed> $investments
+     * @return array<string, mixed>
+     */
+    private function totalSection(AccountEntity $accountEntity, Carbon $dateTo, array $cash, array $investments): array
+    {
+        $balance = round($cash['balance'] + $investments['balance'], 2);
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'total');
+
+        return $this->withCheckpointState([
+            'balance' => $balance,
+        ], $checkpoint, $balance);
+    }
+
+    private function cashBalanceBefore(AccountEntity $accountEntity, Carbon $date): float
+    {
+        return $this->cashBalanceAt($accountEntity, $date->copy()->subDay());
+    }
+
+    private function cashBalanceAt(AccountEntity $accountEntity, Carbon $date): float
+    {
+        $accountEntity->loadMissing('config');
+
+        $openingBalance = $accountEntity->config instanceof Account
+            ? (float) $accountEntity->config->opening_balance
+            : 0.0;
+
+        return round($openingBalance + $this->cashMovements($accountEntity, null, $date)->sum(), 2);
+    }
+
+    /**
+     * @return Collection<int, float>
+     */
+    private function cashMovements(AccountEntity $accountEntity, ?Carbon $dateFrom, Carbon $dateTo): Collection
+    {
+        $standardFrom = DB::table('transactions')
+            ->join('transaction_details_standard', 'transactions.config_id', '=', 'transaction_details_standard.id')
+            ->where('transactions.config_type', 'standard')
+            ->where('transactions.schedule', 0)
+            ->where('transactions.budget', 0)
+            ->where('transaction_details_standard.account_from_id', $accountEntity->id)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
+            ->where('transactions.date', '<=', $dateTo)
+            ->pluck('transaction_details_standard.amount_from')
+            ->map(fn ($amount): float => -1 * (float) $amount);
+
+        $standardTo = DB::table('transactions')
+            ->join('transaction_details_standard', 'transactions.config_id', '=', 'transaction_details_standard.id')
+            ->where('transactions.config_type', 'standard')
+            ->where('transactions.schedule', 0)
+            ->where('transactions.budget', 0)
+            ->where('transaction_details_standard.account_to_id', $accountEntity->id)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
+            ->where('transactions.date', '<=', $dateTo)
+            ->pluck('transaction_details_standard.amount_to')
+            ->map(fn ($amount): float => (float) $amount);
+
+        $investment = DB::table('transactions')
+            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+            ->where('transactions.config_type', 'investment')
+            ->where('transactions.schedule', 0)
+            ->where('transactions.budget', 0)
+            ->where('transaction_details_investment.account_id', $accountEntity->id)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
+            ->where('transactions.date', '<=', $dateTo)
+            ->pluck('transactions.cashflow_value')
+            ->map(fn ($amount): float => (float) $amount);
+
+        return $standardFrom->concat($standardTo)->concat($investment)->values();
+    }
+
+    /**
+     * @return array{value: float, missing_price_count: int}
+     */
+    private function investmentValueAt(AccountEntity $accountEntity, Carbon $date): array
+    {
+        $quantities = $this->quantitiesAt($accountEntity, $date);
+        $missingPriceCount = 0;
+
+        $value = $quantities->sum(function (object $item) use ($date, &$missingPriceCount): float {
+            $quantity = (float) $item->quantity;
+            if ($quantity === 0.0) {
+                return 0.0;
+            }
+
+            $investment = Investment::find($item->investment_id);
+            if ($investment === null) {
+                return 0.0;
+            }
+
+            $price = $this->investmentService->getLatestPrice($investment, 'combined', $date);
+            if ($price === null) {
+                $missingPriceCount++;
+                $price = 0.0;
+            }
+
+            return $quantity * $price;
+        });
+
+        return [
+            'value' => round($value, 2),
+            'missing_price_count' => $missingPriceCount,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function investmentHoldings(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): array
+    {
+        $openingQuantities = $this->quantitiesAt($accountEntity, $dateFrom->copy()->subDay())->keyBy('investment_id');
+        $closingQuantities = $this->quantitiesAt($accountEntity, $dateTo)->keyBy('investment_id');
+        $periodQuantityChanges = $this->periodInvestmentQuantityChanges($accountEntity, $dateFrom, $dateTo)->keyBy('investment_id');
+
+        return $openingQuantities
+            ->keys()
+            ->merge($closingQuantities->keys())
+            ->merge($periodQuantityChanges->keys())
+            ->unique()
+            ->map(function (int $investmentId) use ($openingQuantities, $closingQuantities, $periodQuantityChanges, $dateFrom, $dateTo): ?array {
+                $investment = Investment::find($investmentId);
+                if ($investment === null) {
+                    return null;
+                }
+
+                $openQuantity = (float) ($openingQuantities->get($investmentId)->quantity ?? 0);
+                $closeQuantity = (float) ($closingQuantities->get($investmentId)->quantity ?? 0);
+                $periodChanges = $periodQuantityChanges->get($investmentId);
+                $buys = (float) ($periodChanges->buys ?? 0);
+                $sells = (float) ($periodChanges->sells ?? 0);
+
+                if ($openQuantity === 0.0 && $closeQuantity === 0.0 && $buys === 0.0 && $sells === 0.0) {
+                    return null;
+                }
+
+                $openPrice = $this->investmentService->getLatestPrice($investment, 'combined', $dateFrom);
+                $closePrice = $this->investmentService->getLatestPrice($investment, 'combined', $dateTo);
+                $openStoredPrice = $this->storedPriceForDate($investment, $dateFrom);
+                $closeStoredPrice = $this->storedPriceForDate($investment, $dateTo);
+
+                return [
+                    'investment_id' => $investment->id,
+                    'name' => $investment->name,
+                    'symbol' => $investment->symbol,
+                    'open_quantity' => $openQuantity,
+                    'close_quantity' => $closeQuantity,
+                    'buys' => $buys,
+                    'sells' => $sells,
+                    'open_price' => $openPrice,
+                    'close_price' => $closePrice,
+                    'open_price_date' => $dateFrom->toDateString(),
+                    'close_price_date' => $dateTo->toDateString(),
+                    'open_stored_price_id' => $openStoredPrice?->id,
+                    'close_stored_price_id' => $closeStoredPrice?->id,
+                    'open_value' => round($openQuantity * ($openPrice ?? 0), 2),
+                    'close_value' => round($closeQuantity * ($closePrice ?? 0), 2),
+                    'has_missing_price' => ($openQuantity !== 0.0 && $openPrice === null)
+                        || ($closeQuantity !== 0.0 && $closePrice === null),
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    private function storedPriceForDate(Investment $investment, Carbon $date): ?InvestmentPrice
+    {
+        return InvestmentPrice::where('investment_id', $investment->id)
+            ->whereDate('date', $date)
+            ->first();
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function quantitiesAt(AccountEntity $accountEntity, Carbon $date): Collection
+    {
+        return DB::table('transactions')
+            ->select(
+                'transaction_details_investment.investment_id',
+                DB::raw('SUM('
+                    . TransactionTypeEnum::getQuantityMultiplierSqlCase('transactions.transaction_type')
+                    . ' * IFNULL(transaction_details_investment.quantity, 0)) AS quantity')
+            )
+            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+            ->where('transactions.schedule', 0)
+            ->where('transactions.budget', 0)
+            ->where('transactions.config_type', 'investment')
+            ->whereIn('transactions.transaction_type', TransactionTypeEnum::investmentTypesWithQuantityValues())
+            ->where('transaction_details_investment.account_id', $accountEntity->id)
+            ->where('transactions.date', '<=', $date)
+            ->groupBy('transaction_details_investment.investment_id')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function periodInvestmentQuantityChanges(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): Collection
+    {
+        return DB::table('transactions')
+            ->select('transaction_details_investment.investment_id')
+            ->selectRaw("SUM(CASE WHEN transactions.transaction_type IN ('buy', 'add_shares') THEN IFNULL(transaction_details_investment.quantity, 0) ELSE 0 END) AS buys")
+            ->selectRaw("SUM(CASE WHEN transactions.transaction_type IN ('sell', 'remove_shares') THEN IFNULL(transaction_details_investment.quantity, 0) ELSE 0 END) AS sells")
+            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+            ->where('transactions.schedule', 0)
+            ->where('transactions.budget', 0)
+            ->where('transactions.config_type', 'investment')
+            ->whereIn('transactions.transaction_type', TransactionTypeEnum::investmentTypesWithQuantityValues())
+            ->where('transaction_details_investment.account_id', $accountEntity->id)
+            ->whereBetween('transactions.date', [$dateFrom, $dateTo])
+            ->groupBy('transaction_details_investment.investment_id')
+            ->get();
+    }
+
+    private function checkpointForDate(AccountEntity $accountEntity, Carbon $date, string $type): ?AccountBalanceCheckpoint
+    {
+        return AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
+            ->where('checkpoint_type', $type)
+            ->where('checkpoint_date', $date)
+            ->where('active', true)
+            ->latest('id')
+            ->first();
+    }
+
+    /**
+     * @param array<string, mixed> $section
+     * @return array<string, mixed>
+     */
+    private function withCheckpointState(array $section, ?AccountBalanceCheckpoint $checkpoint, float $calculatedBalance): array
+    {
+        $variance = $checkpoint === null ? null : round($checkpoint->balance - $calculatedBalance, 2);
+
+        return array_merge($section, [
+            'checkpoint' => $checkpoint,
+            'checkpoint_value' => $checkpoint?->balance,
+            'variance' => $variance,
+            'status' => $checkpoint === null
+                ? 'no_checkpoint'
+                : (abs($variance) < 0.01 ? 'matched' : 'reconcile_required'),
+        ]);
+    }
+}

--- a/app/Services/AdvancedReconcileService.php
+++ b/app/Services/AdvancedReconcileService.php
@@ -2,15 +2,18 @@
 
 namespace App\Services;
 
+use App\Enums\CheckpointType;
 use App\Enums\TransactionType as TransactionTypeEnum;
 use App\Models\Account;
 use App\Models\AccountBalanceCheckpoint;
 use App\Models\AccountEntity;
 use App\Models\Investment;
 use App\Models\InvestmentPrice;
+use App\Models\TransactionDetailInvestment;
+use App\Models\TransactionDetailStandard;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 class AdvancedReconcileService
 {
@@ -45,12 +48,15 @@ class AdvancedReconcileService
     /**
      * @return array<string, mixed>
      */
-    public function dashboard(AccountEntity $accountEntity, Carbon $month, string $checkpointType): array
+    public function dashboard(AccountEntity $accountEntity, Carbon $month, CheckpointType $checkpointType): array
     {
         $checkpoint = AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
-            ->where('checkpoint_type', $checkpointType)
+            ->where('checkpoint_type', $checkpointType->value)
             ->where('active', true)
-            ->whereBetween('checkpoint_date', [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()])
+            ->whereBetween('checkpoint_date', [
+                $month->copy()->startOfMonth()->toDateString(),
+                $month->copy()->endOfMonth()->toDateString(),
+            ])
             ->latest('checkpoint_date')
             ->latest('id')
             ->first();
@@ -67,7 +73,7 @@ class AdvancedReconcileService
         }
 
         $previousCheckpointDate = AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
-            ->where('checkpoint_type', $checkpointType)
+            ->where('checkpoint_type', $checkpointType->value)
             ->where('active', true)
             ->where('checkpoint_date', '<', $checkpoint->checkpoint_date)
             ->latest('checkpoint_date')
@@ -90,21 +96,39 @@ class AdvancedReconcileService
         ];
     }
 
-    public function calculatedBalanceAt(AccountEntity $accountEntity, Carbon $date, string $checkpointType): float
+    public function calculatedBalanceAt(AccountEntity $accountEntity, Carbon $date, CheckpointType $checkpointType): float
     {
         $cashBalance = $this->cashBalanceAt($accountEntity, $date);
 
-        if ($checkpointType === 'cash') {
+        if ($checkpointType === CheckpointType::CASH) {
             return $cashBalance;
         }
 
         $investmentBalance = $this->investmentValueAt($accountEntity, $date)['value'];
 
-        if ($checkpointType === 'investment') {
+        if ($checkpointType === CheckpointType::INVESTMENT) {
             return $investmentBalance;
         }
 
         return round($cashBalance + $investmentBalance, 2);
+    }
+
+    /**
+     * @param array{checkpoint_date: string, checkpoint_type: string, balance: numeric, note?: string|null, source?: string|null, source_document_id?: string|null} $data
+     */
+    public function storeCheckpoint(User $user, AccountEntity $accountEntity, array $data): AccountBalanceCheckpoint
+    {
+        return AccountBalanceCheckpoint::create([
+            'user_id' => $user->id,
+            'account_entity_id' => $accountEntity->id,
+            'checkpoint_date' => $data['checkpoint_date'],
+            'checkpoint_type' => CheckpointType::from($data['checkpoint_type'])->value,
+            'balance' => $data['balance'],
+            'note' => $data['note'] ?? null,
+            'active' => true,
+            'source' => $data['source'] ?? 'manual',
+            'source_document_id' => $data['source_document_id'] ?? null,
+        ]);
     }
 
     /**
@@ -118,7 +142,7 @@ class AdvancedReconcileService
         $totalDeposits = round($movements->filter(fn (float $amount): bool => $amount > 0)->sum(), 2);
         $totalWithdrawals = round(abs($movements->filter(fn (float $amount): bool => $amount < 0)->sum()), 2);
         $balance = round($openingBalance + $totalDeposits - $totalWithdrawals, 2);
-        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'cash');
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, CheckpointType::CASH);
 
         return $this->withCheckpointState([
             'opening_balance' => $openingBalance,
@@ -136,7 +160,7 @@ class AdvancedReconcileService
         $opening = $this->investmentValueAt($accountEntity, $dateFrom->copy()->subDay());
         $closing = $this->investmentValueAt($accountEntity, $dateTo);
         $holdings = $this->investmentHoldings($accountEntity, $dateFrom, $dateTo);
-        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'investment');
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, CheckpointType::INVESTMENT);
 
         return $this->withCheckpointState([
             'opening_value' => $opening['value'],
@@ -155,7 +179,7 @@ class AdvancedReconcileService
     private function totalSection(AccountEntity $accountEntity, Carbon $dateTo, array $cash, array $investments): array
     {
         $balance = round($cash['balance'] + $investments['balance'], 2);
-        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, 'total');
+        $checkpoint = $this->checkpointForDate($accountEntity, $dateTo, CheckpointType::TOTAL);
 
         return $this->withCheckpointState([
             'balance' => $balance,
@@ -183,36 +207,36 @@ class AdvancedReconcileService
      */
     private function cashMovements(AccountEntity $accountEntity, ?Carbon $dateFrom, Carbon $dateTo): Collection
     {
-        $standardFrom = DB::table('transactions')
-            ->join('transaction_details_standard', 'transactions.config_id', '=', 'transaction_details_standard.id')
+        $standardFrom = TransactionDetailStandard::query()
+            ->join('transactions', 'transaction_details_standard.id', '=', 'transactions.config_id')
             ->where('transactions.config_type', 'standard')
             ->where('transactions.schedule', 0)
             ->where('transactions.budget', 0)
             ->where('transaction_details_standard.account_from_id', $accountEntity->id)
-            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
-            ->where('transactions.date', '<=', $dateTo)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom->toDateString()))
+            ->where('transactions.date', '<=', $dateTo->toDateString())
             ->pluck('transaction_details_standard.amount_from')
             ->map(fn ($amount): float => -1 * (float) $amount);
 
-        $standardTo = DB::table('transactions')
-            ->join('transaction_details_standard', 'transactions.config_id', '=', 'transaction_details_standard.id')
+        $standardTo = TransactionDetailStandard::query()
+            ->join('transactions', 'transaction_details_standard.id', '=', 'transactions.config_id')
             ->where('transactions.config_type', 'standard')
             ->where('transactions.schedule', 0)
             ->where('transactions.budget', 0)
             ->where('transaction_details_standard.account_to_id', $accountEntity->id)
-            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
-            ->where('transactions.date', '<=', $dateTo)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom->toDateString()))
+            ->where('transactions.date', '<=', $dateTo->toDateString())
             ->pluck('transaction_details_standard.amount_to')
             ->map(fn ($amount): float => (float) $amount);
 
-        $investment = DB::table('transactions')
-            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+        $investment = TransactionDetailInvestment::query()
+            ->join('transactions', 'transaction_details_investment.id', '=', 'transactions.config_id')
             ->where('transactions.config_type', 'investment')
             ->where('transactions.schedule', 0)
             ->where('transactions.budget', 0)
             ->where('transaction_details_investment.account_id', $accountEntity->id)
-            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom))
-            ->where('transactions.date', '<=', $dateTo)
+            ->when($dateFrom, fn ($query) => $query->where('transactions.date', '>=', $dateFrom->toDateString()))
+            ->where('transactions.date', '<=', $dateTo->toDateString())
             ->pluck('transactions.cashflow_value')
             ->map(fn ($amount): float => (float) $amount);
 
@@ -263,13 +287,16 @@ class AdvancedReconcileService
         $closingQuantities = $this->quantitiesAt($accountEntity, $dateTo)->keyBy('investment_id');
         $periodQuantityChanges = $this->periodInvestmentQuantityChanges($accountEntity, $dateFrom, $dateTo)->keyBy('investment_id');
 
-        return $openingQuantities
+        $investmentIds = $openingQuantities
             ->keys()
             ->merge($closingQuantities->keys())
             ->merge($periodQuantityChanges->keys())
-            ->unique()
-            ->map(function (int $investmentId) use ($openingQuantities, $closingQuantities, $periodQuantityChanges, $dateFrom, $dateTo): ?array {
-                $investment = Investment::find($investmentId);
+            ->unique();
+        $investments = Investment::whereIn('id', $investmentIds)->get()->keyBy('id');
+
+        return $investmentIds
+            ->map(function (int $investmentId) use ($investments, $openingQuantities, $closingQuantities, $periodQuantityChanges, $dateFrom, $dateTo): ?array {
+                $investment = $investments->get($investmentId);
                 if ($investment === null) {
                     return null;
                 }
@@ -305,8 +332,8 @@ class AdvancedReconcileService
                     'close_stored_price_id' => $closeStoredPrice?->id,
                     'open_value' => round($openQuantity * ($openPrice ?? 0), 2),
                     'close_value' => round($closeQuantity * ($closePrice ?? 0), 2),
-                    'has_missing_price' => ($openQuantity !== 0.0 && $openPrice === null)
-                        || ($closeQuantity !== 0.0 && $closePrice === null),
+                    'has_missing_price' => (($openQuantity !== 0.0 && $openPrice === null)
+                        || ($closeQuantity !== 0.0 && $closePrice === null)),
                 ];
             })
             ->filter()
@@ -326,20 +353,22 @@ class AdvancedReconcileService
      */
     private function quantitiesAt(AccountEntity $accountEntity, Carbon $date): Collection
     {
-        return DB::table('transactions')
+        return TransactionDetailInvestment::query()
             ->select(
                 'transaction_details_investment.investment_id',
-                DB::raw('SUM('
-                    . TransactionTypeEnum::getQuantityMultiplierSqlCase('transactions.transaction_type')
-                    . ' * IFNULL(transaction_details_investment.quantity, 0)) AS quantity')
             )
-            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+            ->selectRaw(
+                'SUM('
+                . TransactionTypeEnum::getQuantityMultiplierSqlCase('transactions.transaction_type')
+                . ' * IFNULL(transaction_details_investment.quantity, 0)) AS quantity'
+            )
+            ->join('transactions', 'transaction_details_investment.id', '=', 'transactions.config_id')
             ->where('transactions.schedule', 0)
             ->where('transactions.budget', 0)
             ->where('transactions.config_type', 'investment')
             ->whereIn('transactions.transaction_type', TransactionTypeEnum::investmentTypesWithQuantityValues())
             ->where('transaction_details_investment.account_id', $accountEntity->id)
-            ->where('transactions.date', '<=', $date)
+            ->where('transactions.date', '<=', $date->toDateString())
             ->groupBy('transaction_details_investment.investment_id')
             ->get();
     }
@@ -349,26 +378,26 @@ class AdvancedReconcileService
      */
     private function periodInvestmentQuantityChanges(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): Collection
     {
-        return DB::table('transactions')
+        return TransactionDetailInvestment::query()
             ->select('transaction_details_investment.investment_id')
             ->selectRaw("SUM(CASE WHEN transactions.transaction_type IN ('buy', 'add_shares') THEN IFNULL(transaction_details_investment.quantity, 0) ELSE 0 END) AS buys")
             ->selectRaw("SUM(CASE WHEN transactions.transaction_type IN ('sell', 'remove_shares') THEN IFNULL(transaction_details_investment.quantity, 0) ELSE 0 END) AS sells")
-            ->join('transaction_details_investment', 'transactions.config_id', '=', 'transaction_details_investment.id')
+            ->join('transactions', 'transaction_details_investment.id', '=', 'transactions.config_id')
             ->where('transactions.schedule', 0)
             ->where('transactions.budget', 0)
             ->where('transactions.config_type', 'investment')
             ->whereIn('transactions.transaction_type', TransactionTypeEnum::investmentTypesWithQuantityValues())
             ->where('transaction_details_investment.account_id', $accountEntity->id)
-            ->whereBetween('transactions.date', [$dateFrom, $dateTo])
+            ->whereBetween('transactions.date', [$dateFrom->toDateString(), $dateTo->toDateString()])
             ->groupBy('transaction_details_investment.investment_id')
             ->get();
     }
 
-    private function checkpointForDate(AccountEntity $accountEntity, Carbon $date, string $type): ?AccountBalanceCheckpoint
+    private function checkpointForDate(AccountEntity $accountEntity, Carbon $date, CheckpointType $type): ?AccountBalanceCheckpoint
     {
         return AccountBalanceCheckpoint::where('account_entity_id', $accountEntity->id)
-            ->where('checkpoint_type', $type)
-            ->where('checkpoint_date', $date)
+            ->where('checkpoint_type', $type->value)
+            ->where('checkpoint_date', $date->toDateString())
             ->where('active', true)
             ->latest('id')
             ->first();

--- a/app/Services/AdvancedReconcileService.php
+++ b/app/Services/AdvancedReconcileService.php
@@ -349,7 +349,7 @@ class AdvancedReconcileService
     }
 
     /**
-     * @return Collection<int, object>
+     * @return Collection<int, TransactionDetailInvestment>
      */
     private function quantitiesAt(AccountEntity $accountEntity, Carbon $date): Collection
     {
@@ -374,7 +374,7 @@ class AdvancedReconcileService
     }
 
     /**
-     * @return Collection<int, object>
+     * @return Collection<int, TransactionDetailInvestment>
      */
     private function periodInvestmentQuantityChanges(AccountEntity $accountEntity, Carbon $dateFrom, Carbon $dateTo): Collection
     {

--- a/database/factories/AccountBalanceCheckpointFactory.php
+++ b/database/factories/AccountBalanceCheckpointFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Account;
+use App\Models\AccountEntity;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\AccountBalanceCheckpoint>
+ */
+class AccountBalanceCheckpointFactory extends Factory
+{
+    public function definition(): array
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        return [
+            'user_id' => $user->id,
+            'account_entity_id' => AccountEntity::factory()
+                ->for($user)
+                ->for(Account::factory()->withUser($user), 'config')
+                ->create()
+                ->id,
+            'checkpoint_date' => $this->faker->date('Y-m-d'),
+            'checkpoint_type' => $this->faker->randomElement(['cash', 'investment', 'total']),
+            'balance' => $this->faker->randomFloat(2, 0, 10000),
+            'note' => $this->faker->boolean(35) ? $this->faker->sentence() : null,
+            'active' => true,
+            'source' => 'manual',
+            'source_document_id' => null,
+        ];
+    }
+
+    public function forAccount(AccountEntity $accountEntity): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'user_id' => $accountEntity->user_id,
+            'account_entity_id' => $accountEntity->id,
+        ]);
+    }
+}

--- a/database/factories/AccountBalanceCheckpointFactory.php
+++ b/database/factories/AccountBalanceCheckpointFactory.php
@@ -14,16 +14,18 @@ class AccountBalanceCheckpointFactory extends Factory
 {
     public function definition(): array
     {
-        /** @var User $user */
-        $user = User::factory()->create();
-
         return [
-            'user_id' => $user->id,
-            'account_entity_id' => AccountEntity::factory()
-                ->for($user)
-                ->for(Account::factory()->withUser($user), 'config')
-                ->create()
-                ->id,
+            'user_id' => User::factory(),
+            'account_entity_id' => function (array $attributes): int {
+                /** @var User $user */
+                $user = User::find($attributes['user_id']) ?? User::factory()->create();
+
+                return AccountEntity::factory()
+                    ->for($user)
+                    ->for(Account::factory()->withUser($user), 'config')
+                    ->create()
+                    ->id;
+            },
             'checkpoint_date' => $this->faker->date('Y-m-d'),
             'checkpoint_type' => $this->faker->randomElement(['cash', 'investment', 'total']),
             'balance' => $this->faker->randomFloat(2, 0, 10000),

--- a/database/migrations/2026_07_06_000001_create_account_balance_checkpoints_table.php
+++ b/database/migrations/2026_07_06_000001_create_account_balance_checkpoints_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('account_balance_checkpoints', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('account_entity_id')->constrained('account_entities')->cascadeOnDelete();
+            $table->date('checkpoint_date');
+            $table->enum('checkpoint_type', ['cash', 'total', 'investment'])->default('cash');
+            $table->decimal('balance', 15, 2);
+            $table->text('note')->nullable();
+            $table->boolean('active')->default(true);
+            $table->string('source')->default('manual');
+            $table->string('source_document_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['source', 'source_document_id'], 'uniq_account_balance_checkpoint_source_document');
+            $table->index('user_id');
+            $table->index('account_entity_id');
+            $table->index(['account_entity_id', 'checkpoint_type', 'checkpoint_date'], 'idx_account_balance_checkpoint_lookup');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('account_balance_checkpoints');
+    }
+};

--- a/database/migrations/2026_07_06_000001_create_account_balance_checkpoints_table.php
+++ b/database/migrations/2026_07_06_000001_create_account_balance_checkpoints_table.php
@@ -23,7 +23,7 @@ return new class () extends Migration {
             $table->string('source_document_id')->nullable();
             $table->timestamps();
 
-            $table->unique(['source', 'source_document_id'], 'uniq_account_balance_checkpoint_source_document');
+            $table->unique(['account_entity_id', 'source', 'source_document_id'], 'uniq_account_balance_checkpoint_source_document');
             $table->index('user_id');
             $table->index('account_entity_id');
             $table->index(['account_entity_id', 'checkpoint_type', 'checkpoint_date'], 'idx_account_balance_checkpoint_lookup');

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -577,6 +577,8 @@ function renderAdvancedReconcileHoldings(holdings) {
             '<td class="text-end">' + holding.sells + '</td>' +
             '<td class="text-end">' + renderHoldingPriceButton(holding, 'open') + '</td>' +
             '<td class="text-end">' + renderHoldingPriceButton(holding, 'close') + '</td>' +
+             '<td class="text-end">' + formatAccountCurrency(holding.open_value)  + '</td>' +
+            '<td class="text-end">' + formatAccountCurrency(holding.close_value) + '</td>' +
             '</tr>';
     }).join('');
 }

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -3,6 +3,7 @@ import 'datatables.net-responsive-bs5';
 
 import * as dataTableHelpers from '@/shared/lib/datatable';
 import * as helpers from '@/shared/lib/helpers';
+import { escapeHtml, jsonFromResponse } from '@/shared/lib/helpers';
 import { getDataTablesLanguageOptions, toFormattedCurrency } from '@/shared/lib/i18n';
 import * as toastHelpers from '@/shared/lib/toast';
 import { initializeTwoColumnLeftControlPanelToggle } from '@/shared/lib/ui/leftControlPanelToggle';
@@ -39,10 +40,6 @@ let advancedReconcileData = null;
 let advancedReconcilePriceModal = null;
 let advancedReconcilePriceContext = null;
 
-function escapeHtml(value) {
-    return $('<div>').text(value ?? '').html();
-}
-
 let currentDateFilters = {
     dateFrom: window.filters?.date_from || null,
     dateTo: window.filters?.date_to || null,
@@ -53,6 +50,28 @@ const hasInitialFilters =
     !!currentDateFilters.dateFrom ||
     !!currentDateFilters.dateTo ||
     (!!currentDateFilters.preset && currentDateFilters.preset !== 'none');
+
+function accountDatePresetGroups() {
+    const presetGroups = window.YAFFA?.config?.datePresets || [];
+    const checkpointWindows = window.checkpointWindows || [];
+
+    if (!checkpointWindows.length) {
+        return presetGroups;
+    }
+
+    return [
+        ...presetGroups,
+        {
+            label: 'Checkpoint windows',
+            options: checkpointWindows.map((windowOption) => ({
+                value: windowOption.value,
+                label: windowOption.label,
+                date_from: windowOption.date_from,
+                date_to: windowOption.date_to,
+            })),
+        },
+    ];
+}
 
 /**
  * Helper function to get adjusted cash flow in the context of the current account
@@ -493,6 +512,7 @@ const dateRangeApp = createApp({
             initialDateFrom: currentDateFilters.dateFrom,
             initialDateTo: currentDateFilters.dateTo,
             initialPreset: currentDateFilters.preset,
+            presetGroups: accountDatePresetGroups(),
         };
     },
     methods: {
@@ -630,13 +650,7 @@ function loadAdvancedReconcile() {
             'X-CSRF-TOKEN': window.csrfToken,
         },
     })
-        .then(async (response) => {
-            const data = await response.json();
-            if (!response.ok) {
-                throw new Error(data.message || response.statusText);
-            }
-            return data;
-        })
+        .then(jsonFromResponse)
         .then(renderAdvancedReconcile)
         .catch(error => toastHelpers.showErrorToast(error.message));
 }

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -630,7 +630,13 @@ function loadAdvancedReconcile() {
             'X-CSRF-TOKEN': window.csrfToken,
         },
     })
-        .then(response => response.json())
+        .then(async (response) => {
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || response.statusText);
+            }
+            return data;
+        })
         .then(renderAdvancedReconcile)
         .catch(error => toastHelpers.showErrorToast(error.message));
 }

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -660,7 +660,7 @@ document.querySelectorAll('[data-checkpoint-type]').forEach((button) => {
             toastHelpers.showSuccessToast(__('Checkpoint saved'));
             loadAdvancedReconcile();
         }).catch((error) => {
-            toastHelpers.showErrorToast(error.message);
+            toastHelpers.showErrorToast(error.response?.data?.message || error.message);
         });
     });
 });

--- a/resources/js/account/show.js
+++ b/resources/js/account/show.js
@@ -13,6 +13,35 @@ const selectorHistoryTable = '#historyTable';
 const selectorLeftControlPanel = '#accountLeftControlPanel';
 const selectorMainContent = '#accountMainContent';
 const selectorLeftControlPanelToggleButton = '#toggleAccountLeftControlPanelButton';
+const reconcileSectionLabels = {
+    cash: {
+        opening_balance: __('Opening balance'),
+        total_withdrawals: __('Total withdrawals'),
+        total_deposits: __('Total deposits'),
+        balance: __('Balance'),
+        checkpoint_value: __('Checkpoint value'),
+        variance: __('Variance / Match'),
+    },
+    investment: {
+        opening_value: __('Opening investment value'),
+        closing_value: __('Closing investment value'),
+        checkpoint_value: __('Checkpoint value'),
+        variance: __('Variance / Match'),
+    },
+    total: {
+        balance: __('Balance'),
+        checkpoint_value: __('Checkpoint value'),
+        variance: __('Variance / Match'),
+    },
+};
+
+let advancedReconcileData = null;
+let advancedReconcilePriceModal = null;
+let advancedReconcilePriceContext = null;
+
+function escapeHtml(value) {
+    return $('<div>').text(value ?? '').html();
+}
 
 let currentDateFilters = {
     dateFrom: window.filters?.date_from || null,
@@ -451,6 +480,7 @@ const handleDateRangeUpdated = ({dateFrom, dateTo, preset}) => {
         preset: preset || null,
     };
 
+    loadAdvancedReconcile();
     reloadTable();
 };
 
@@ -479,6 +509,319 @@ const dateRangeApp = createApp({
 
 installRouteGlobal(dateRangeApp);
 dateRangeApp.mount('#account-date-range-filter');
+
+function formatAccountCurrency(value) {
+    return toFormattedCurrency(
+        value || 0,
+        window.YAFFA.userSettings.locale,
+        window.account.config.currency
+    );
+}
+
+function renderCheckpointValue(section) {
+    if (!section.checkpoint) {
+        return '<span class="text-muted">' + __('No checkpoint') + '</span>';
+    }
+
+    const note = section.checkpoint.note ? ' title="' + escapeHtml(section.checkpoint.note) + '"' : '';
+    return '<span' + note + '>' + formatAccountCurrency(section.checkpoint.balance) + '</span>';
+}
+
+function renderVariance(section) {
+    if (section.status === 'no_checkpoint') {
+        return '<span class="text-muted">' + __('No checkpoint') + '</span>';
+    }
+
+    if (section.status === 'matched') {
+        return '<span class="text-success"><i class="fa-solid fa-check"></i> ' + __('Matched') + '</span>';
+    }
+
+    return '<span class="text-warning"><i class="fa-solid fa-triangle-exclamation"></i> ' +
+        formatAccountCurrency(section.variance) +
+        '</span>';
+}
+
+function renderAdvancedReconcileSection(type, data) {
+    const element = document.querySelector('[data-reconcile-section="' + type + '"]');
+    if (!element) {
+        return;
+    }
+
+    const labels = reconcileSectionLabels[type];
+    element.innerHTML = Object.keys(labels).map((key) => {
+        const value = key === 'checkpoint_value'
+            ? renderCheckpointValue(data)
+            : (key === 'variance' ? renderVariance(data) : formatAccountCurrency(data[key]));
+
+        return '<dt class="col-7">' + labels[key] + '</dt><dd class="col-5 text-end">' + value + '</dd>';
+    }).join('');
+}
+
+function renderAdvancedReconcileHoldings(holdings) {
+    const body = document.getElementById('advancedReconcileHoldingsBody');
+    if (!body) {
+        return;
+    }
+
+    if (!holdings.length) {
+        body.innerHTML = '<tr><td colspan="7" class="text-muted">' + __('No investment holdings in this period') + '</td></tr>';
+        return;
+    }
+
+    body.innerHTML = holdings.map((holding) => {
+        return '<tr class="' + (holding.has_missing_price ? 'table-warning' : '') + '">' +
+            '<td>' + escapeHtml(holding.name) + '</td>' +
+            '<td class="text-end">' + holding.open_quantity + '</td>' +
+            '<td class="text-end">' + holding.close_quantity + '</td>' +
+            '<td class="text-end">' + holding.buys + '</td>' +
+            '<td class="text-end">' + holding.sells + '</td>' +
+            '<td class="text-end">' + renderHoldingPriceButton(holding, 'open') + '</td>' +
+            '<td class="text-end">' + renderHoldingPriceButton(holding, 'close') + '</td>' +
+            '</tr>';
+    }).join('');
+}
+
+function renderHoldingPriceButton(holding, side) {
+    const quantity = side === 'open' ? holding.open_quantity : holding.close_quantity;
+    const price = side === 'open' ? holding.open_price : holding.close_price;
+    const value = side === 'open' ? holding.open_value : holding.close_value;
+    const date = side === 'open' ? holding.open_price_date : holding.close_price_date;
+    const storedPriceId = side === 'open' ? holding.open_stored_price_id : holding.close_stored_price_id;
+    const isMissing = quantity !== 0 && price === null;
+    const label = isMissing ? __('Missing') : formatAccountCurrency(price);
+    const className = isMissing ? 'btn btn-xs btn-outline-warning' : 'btn btn-xs btn-link p-0 text-decoration-none';
+
+    return '<button type="button" class="' + className + '" ' +
+        'data-price-investment="' + holding.investment_id + '" ' +
+        'data-price-date="' + date + '" ' +
+        'data-price-side="' + side + '" ' +
+        'data-price-quantity="' + quantity + '" ' +
+        'data-price-current="' + (price ?? '') + '" ' +
+        'data-price-current-value="' + (value ?? '') + '" ' +
+        'data-price-stored-id="' + (storedPriceId ?? '') + '" ' +
+        'data-price-investment-name="' + escapeHtml(holding.name) + '">' +
+        label +
+        '</button>';
+}
+
+function renderAdvancedReconcile(data) {
+    advancedReconcileData = data;
+    renderAdvancedReconcileSection('cash', data.cash);
+    renderAdvancedReconcileSection('investment', data.investment);
+    renderAdvancedReconcileSection('total', data.total);
+    renderAdvancedReconcileHoldings(data.investment.holdings || []);
+    helpers.initializeBootstrapTooltips();
+}
+
+function loadAdvancedReconcile() {
+    const params = new URLSearchParams();
+    if (currentDateFilters.dateFrom) {
+        params.append('date_from', currentDateFilters.dateFrom);
+    }
+    if (currentDateFilters.dateTo) {
+        params.append('date_to', currentDateFilters.dateTo);
+    }
+
+    fetch('/api/v1/accounts/' + window.account.id + '/advanced-reconcile?' + params, {
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN': window.csrfToken,
+        },
+    })
+        .then(response => response.json())
+        .then(renderAdvancedReconcile)
+        .catch(error => toastHelpers.showErrorToast(error.message));
+}
+
+document.querySelectorAll('[data-checkpoint-type]').forEach((button) => {
+    button.addEventListener('click', () => {
+        if (!advancedReconcileData) {
+            return;
+        }
+
+        const type = button.dataset.checkpointType;
+        const section = advancedReconcileData[type];
+        const balance = type === 'investment' ? section.closing_value : section.balance;
+        const checkpointValue = prompt(__('Checkpoint value'), balance);
+        if (checkpointValue === null) {
+            return;
+        }
+
+        const note = prompt(__('Checkpoint note'), '');
+
+        axios.post('/api/v1/accounts/' + window.account.id + '/balance-checkpoints', {
+            checkpoint_date: advancedReconcileData.date_to,
+            checkpoint_type: type,
+            balance: checkpointValue,
+            note: note,
+        }).then(() => {
+            toastHelpers.showSuccessToast(__('Checkpoint saved'));
+            loadAdvancedReconcile();
+        }).catch((error) => {
+            toastHelpers.showErrorToast(error.message);
+        });
+    });
+});
+
+document.getElementById('advancedReconcileHoldingsBody')?.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-price-investment]');
+    if (!button) {
+        return;
+    }
+
+    openAdvancedReconcilePriceModal(button);
+});
+
+function ensureAdvancedReconcilePriceModal() {
+    let element = document.getElementById('advancedReconcilePriceModal');
+    if (!element) {
+        document.body.insertAdjacentHTML('beforeend', `
+            <div class="modal fade" id="advancedReconcilePriceModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <form class="modal-content" id="advancedReconcilePriceForm">
+                        <div class="modal-header">
+                            <h5 class="modal-title">${__('Set investment price')}</h5>
+                            <button type="button" class="btn-close" data-coreui-dismiss="modal" data-bs-dismiss="modal" aria-label="${__('Close')}"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="mb-3">
+                                <div class="fw-semibold" id="advancedReconcilePriceInvestment"></div>
+                                <div class="text-muted small" id="advancedReconcilePriceMeta"></div>
+                            </div>
+                            <ul class="nav nav-tabs" role="tablist">
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link active" id="advancedReconcilePriceTab" data-bs-toggle="tab" data-coreui-toggle="tab" data-bs-target="#advancedReconcilePricePanel" data-coreui-target="#advancedReconcilePricePanel" type="button" role="tab">
+                                        ${__('Price at date')}
+                                    </button>
+                                </li>
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link" id="advancedReconcileValueTab" data-bs-toggle="tab" data-coreui-toggle="tab" data-bs-target="#advancedReconcileValuePanel" data-coreui-target="#advancedReconcileValuePanel" type="button" role="tab">
+                                        ${__('Value at date')}
+                                    </button>
+                                </li>
+                            </ul>
+                            <div class="tab-content border border-top-0 p-3 mb-3">
+                                <div class="tab-pane fade show active" id="advancedReconcilePricePanel" role="tabpanel" tabindex="0">
+                                    <label class="form-label" for="advancedReconcilePriceInput">${__('Investment price')}</label>
+                                    <input type="number" min="0.0000000001" step="0.0000000001" class="form-control" id="advancedReconcilePriceInput" required>
+                                </div>
+                                <div class="tab-pane fade" id="advancedReconcileValuePanel" role="tabpanel" tabindex="0">
+                                    <label class="form-label" for="advancedReconcileValueInput">${__('Holding value')}</label>
+                                    <input type="number" min="0.01" step="0.01" class="form-control" id="advancedReconcileValueInput">
+                                    <div class="form-text" id="advancedReconcileValueHelp"></div>
+                                </div>
+                            </div>
+                            <div class="alert alert-danger d-none" id="advancedReconcilePriceError"></div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-coreui-dismiss="modal" data-bs-dismiss="modal">${__('Cancel')}</button>
+                            <button type="submit" class="btn btn-primary">${__('Save price')}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        `);
+
+        element = document.getElementById('advancedReconcilePriceModal');
+        document.getElementById('advancedReconcilePriceForm').addEventListener('submit', saveAdvancedReconcilePrice);
+    }
+
+    if (!advancedReconcilePriceModal) {
+        if (window.coreui && window.coreui.Modal) {
+            advancedReconcilePriceModal = new window.coreui.Modal(element);
+        } else {
+            advancedReconcilePriceModal = new window.bootstrap.Modal(element);
+        }
+    }
+
+    return element;
+}
+
+function openAdvancedReconcilePriceModal(button) {
+    const element = ensureAdvancedReconcilePriceModal();
+    const quantity = Number(button.dataset.priceQuantity || 0);
+    const currentPrice = button.dataset.priceCurrent ? Number(button.dataset.priceCurrent) : null;
+    const currentValue = button.dataset.priceCurrentValue ? Number(button.dataset.priceCurrentValue) : null;
+
+    advancedReconcilePriceContext = {
+        investmentId: button.dataset.priceInvestment,
+        storedPriceId: button.dataset.priceStoredId || null,
+        date: button.dataset.priceDate,
+        side: button.dataset.priceSide,
+        quantity: quantity,
+    };
+
+    element.querySelector('#advancedReconcilePriceInvestment').textContent = button.dataset.priceInvestmentName || '';
+    element.querySelector('#advancedReconcilePriceMeta').textContent = __(':side price for :date', {
+        side: button.dataset.priceSide === 'open' ? __('Opening') : __('Closing'),
+        date: button.dataset.priceDate,
+    });
+    element.querySelector('#advancedReconcilePriceInput').value = currentPrice ?? '';
+    element.querySelector('#advancedReconcileValueInput').value = currentValue || '';
+    element.querySelector('#advancedReconcileValueHelp').textContent = __('Quantity at this date: :quantity', {
+        quantity: quantity,
+    });
+    element.querySelector('#advancedReconcilePriceError').classList.add('d-none');
+
+    const valueTab = element.querySelector('#advancedReconcileValueTab');
+    valueTab.disabled = quantity === 0;
+    element.querySelector('#advancedReconcilePriceTab').click();
+
+    advancedReconcilePriceModal.show();
+}
+
+function saveAdvancedReconcilePrice(event) {
+    event.preventDefault();
+
+    const modalElement = document.getElementById('advancedReconcilePriceModal');
+    const errorElement = modalElement.querySelector('#advancedReconcilePriceError');
+    const useValue = modalElement.querySelector('#advancedReconcileValuePanel').classList.contains('active');
+    const rawPrice = Number(modalElement.querySelector('#advancedReconcilePriceInput').value);
+    const rawValue = Number(modalElement.querySelector('#advancedReconcileValueInput').value);
+    let price = rawPrice;
+
+    errorElement.classList.add('d-none');
+
+    if (useValue) {
+        if (!advancedReconcilePriceContext.quantity) {
+            errorElement.textContent = __('A holding value can only be converted when the quantity is not zero.');
+            errorElement.classList.remove('d-none');
+            return;
+        }
+
+        price = rawValue / advancedReconcilePriceContext.quantity;
+    }
+
+    if (!Number.isFinite(price) || price <= 0) {
+        errorElement.textContent = __('Enter a price greater than zero.');
+        errorElement.classList.remove('d-none');
+        return;
+    }
+
+    const payload = {
+        investment_id: advancedReconcilePriceContext.investmentId,
+        date: advancedReconcilePriceContext.date,
+        price: Number(price.toFixed(10)),
+    };
+
+    const request = advancedReconcilePriceContext.storedPriceId
+        ? axios.put('/api/v1/investment-prices/' + advancedReconcilePriceContext.storedPriceId, {
+            ...payload,
+            id: advancedReconcilePriceContext.storedPriceId,
+        })
+        : axios.post('/api/v1/investment-prices', payload);
+
+    request.then(() => {
+        toastHelpers.showSuccessToast(__('Investment price saved'));
+        advancedReconcilePriceModal.hide();
+        loadAdvancedReconcile();
+    }).catch((error) => {
+        errorElement.textContent = error.response?.data?.message || error.message;
+        errorElement.classList.remove('d-none');
+    });
+}
+
+loadAdvancedReconcile();
 
 // Set up event listener for new standard transaction button
 $('#create-standard-transaction-button').on('click', function () {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -53,6 +53,7 @@ const routeMap = new Map([
     ['investment-price.list', 'investment-price/list'],
     ['report.schedules', 'reports/schedules'],
     ['reports.cashflow', 'reports/cashflow'],
+    ['reports.advanced-reconcile', 'reports/advanced-reconcile'],
     ['reports.budgetchart', 'reports/budgetchart'],
     ['reports.transactions', 'reports/transactions'],
     ['reports.investment_timeline', 'reports/investment-timeline'],

--- a/resources/js/reports/advanced-reconcile.js
+++ b/resources/js/reports/advanced-reconcile.js
@@ -1,0 +1,98 @@
+import { __ } from '@/shared/lib/i18n';
+import { toFormattedCurrency } from '@/shared/lib/i18n';
+import * as toastHelpers from '@/shared/lib/toast';
+
+const table = document.getElementById('advancedReconcileDashboard');
+const typeSelect = document.getElementById('advancedReconcileType');
+const displaySelect = document.getElementById('advancedReconcileDisplay');
+const reloadButton = document.getElementById('advancedReconcileReload');
+
+const statusLabels = {
+    matched: __('Matched'),
+    reconcile_required: __('Reconcile required'),
+    no_checkpoint: __('No checkpoint'),
+};
+
+function escapeHtml(value) {
+    const element = document.createElement('div');
+    element.textContent = value ?? '';
+    return element.innerHTML;
+}
+
+function formatAmount(value, currency) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return toFormattedCurrency(value, window.YAFFA.userSettings.locale, currency || window.YAFFA.userSettings.baseCurrency);
+}
+
+function cellClass(status) {
+    if (status === 'matched') {
+        return 'table-success';
+    }
+    if (status === 'reconcile_required') {
+        return 'table-warning';
+    }
+    return 'table-light text-muted';
+}
+
+function reconcileUrl(accountId, cell) {
+    return window.route('account-entity.show', {
+        account_entity: accountId,
+        date_from: cell.date_from,
+        date_to: cell.date_to,
+    });
+}
+
+function render(data) {
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+
+    thead.innerHTML = '<tr><th>' + __('Account') + '</th>' +
+        data.months.map(month => '<th class="text-end">' + month.label + '</th>').join('') +
+        '</tr>';
+
+    tbody.innerHTML = data.rows.map((row) => {
+        const cells = data.months.map((month) => {
+            const cell = row.months[month.key];
+            const href = reconcileUrl(row.account.id, cell);
+            const content = displaySelect.value === 'balance'
+                ? formatAmount(cell.checkpoint?.balance, row.account.currency)
+                : (cell.status === 'reconcile_required'
+                    ? statusLabels[cell.status] + ' (' + formatAmount(cell.variance, row.account.currency) + ')'
+                    : statusLabels[cell.status]);
+
+            return '<td class="text-end ' + cellClass(cell.status) + '">' +
+                '<a href="' + href + '" class="link-dark text-decoration-none d-block">' + content + '</a>' +
+                '</td>';
+        }).join('');
+
+        return '<tr><th scope="row">' + escapeHtml(row.account.name) + '</th>' + cells + '</tr>';
+    }).join('');
+}
+
+function loadDashboard() {
+    reloadButton.disabled = true;
+
+    const url = window.route('api.v1.reports.advanced-reconcile', {
+        checkpoint_type: typeSelect.value,
+        display: displaySelect.value,
+    });
+
+    fetch(url)
+        .then(response => response.json())
+        .then(render)
+        .catch((error) => {
+            toastHelpers.showErrorToast(error.message);
+        })
+        .finally(() => {
+            reloadButton.disabled = false;
+        });
+}
+
+typeSelect.addEventListener('change', loadDashboard);
+displaySelect.addEventListener('change', loadDashboard);
+reloadButton.addEventListener('click', loadDashboard);
+
+loadDashboard();

--- a/resources/js/reports/advanced-reconcile.js
+++ b/resources/js/reports/advanced-reconcile.js
@@ -1,3 +1,4 @@
+import { escapeHtml, jsonFromResponse } from '@/shared/lib/helpers';
 import { __ } from '@/shared/lib/i18n';
 import { toFormattedCurrency } from '@/shared/lib/i18n';
 import * as toastHelpers from '@/shared/lib/toast';
@@ -12,12 +13,6 @@ const statusLabels = {
     reconcile_required: __('Reconcile required'),
     no_checkpoint: __('No checkpoint'),
 };
-
-function escapeHtml(value) {
-    const element = document.createElement('div');
-    element.textContent = value ?? '';
-    return element.innerHTML;
-}
 
 function formatAmount(value, currency) {
     if (value === null || value === undefined) {
@@ -81,7 +76,7 @@ function loadDashboard() {
     });
 
     fetch(url)
-        .then(response => response.json())
+        .then(jsonFromResponse)
         .then(render)
         .catch((error) => {
             toastHelpers.showErrorToast(error.message);

--- a/resources/js/shared/lib/helpers/index.js
+++ b/resources/js/shared/lib/helpers/index.js
@@ -44,6 +44,22 @@ export function escapeHtmlWithLineBreaks(value) {
 }
 
 /**
+ * Parse a fetch response as JSON and throw server-provided errors for non-2xx responses.
+ *
+ * @param {Response} response
+ * @returns {Promise<*>}
+ */
+export async function jsonFromResponse(response) {
+    const data = await response.json();
+
+    if (!response.ok) {
+        throw new Error(data.message || response.statusText);
+    }
+
+    return data;
+}
+
+/**
  * Parse an ISO date-only string ("YYYY-MM-DD") as a local calendar date.
  *
  * new Date("YYYY-MM-DD") is specified to treat the string as UTC midnight,

--- a/resources/js/shared/ui/date/DateRangeFilterCard.vue
+++ b/resources/js/shared/ui/date/DateRangeFilterCard.vue
@@ -136,6 +136,29 @@
     return `${y}-${m}-${day}`;
   }
 
+  function findPresetOption(groups, preset) {
+    if (!preset || preset === 'none') {
+      return null;
+    }
+
+    return (groups || [])
+      .flatMap((group) => group.options || [])
+      .find((option) => option.value === preset) || null;
+  }
+
+  function resolvePresetDates(preset, groups) {
+    const option = findPresetOption(groups, preset);
+    if (option?.date_from && option?.date_to) {
+      return {
+        start: parseDate(option.date_from),
+        end: parseDate(option.date_to),
+      };
+    }
+
+    const calculator = presetCalculators[preset];
+    return calculator ? calculator(new Date()) : null;
+  }
+
   export default {
     name: 'DateRangeFilterCard',
     components: { DatePicker },
@@ -188,9 +211,8 @@
       let dateTo = this.initialDateTo;
 
       if (!dateFrom && !dateTo && preset !== 'none') {
-        const calculator = presetCalculators[preset];
-        if (calculator) {
-          const dates = calculator(new Date());
+        const dates = resolvePresetDates(preset, this.presetGroups);
+        if (dates) {
           dateFrom = formatDate(dates.start);
           dateTo = formatDate(dates.end);
         }
@@ -269,9 +291,8 @@
     },
     methods: {
       onPresetChange() {
-        const calculator = presetCalculators[this.selectedPreset];
-        if (calculator) {
-          const dates = calculator(new Date());
+        const dates = resolvePresetDates(this.selectedPreset, this.presetGroups);
+        if (dates) {
           this.dateFrom = formatDate(dates.start);
           this.dateTo = formatDate(dates.end);
         } else {

--- a/resources/views/accounts/show.blade.php
+++ b/resources/views/accounts/show.blade.php
@@ -111,6 +111,7 @@
                 :initial-date-from="initialDateFrom"
                 :initial-date-to="initialDateTo"
                 :initial-preset="initialPreset"
+                :preset-groups="presetGroups"
                 :update-url="true"
                 ref="dateFilter"
                 @update="onDateRangeUpdated"

--- a/resources/views/accounts/show.blade.php
+++ b/resources/views/accounts/show.blade.php
@@ -193,7 +193,7 @@
                                         </thead>
                                         <tbody id="advancedReconcileHoldingsBody">
                                             <tr>
-                                                <td colspan="7"><i class="fa fa-fw fa-spinner fa-spin"></i></td>
+                                                <td colspan="9"><i class="fa fa-fw fa-spinner fa-spin"></i></td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/resources/views/accounts/show.blade.php
+++ b/resources/views/accounts/show.blade.php
@@ -131,6 +131,75 @@
             >
                 <i class="fas fa-angles-left" data-left-control-panel-toggle-icon></i>
             </button>
+            <div class="card mb-3" id="advancedReconcileCard">
+                <div class="card-header">
+                    <div class="card-title collapsed collapse-control" data-coreui-toggle="collapse"
+                        data-coreui-target="#advancedReconcileBody">
+                        <i class="fa fa-angle-down"></i>
+                        {{ __('Advanced reconcile') }}
+                    </div>
+                </div>
+                <div class="collapse" aria-expanded="false" id="advancedReconcileBody">
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-12 col-xl-4">
+                                <h3 class="h6">{{ __('Cash') }}</h3>
+                                <dl class="row mb-2" data-reconcile-section="cash"></dl>
+                                <button type="button" class="btn btn-sm btn-outline-primary" data-checkpoint-type="cash">
+                                    <i class="fa-solid fa-bookmark"></i>
+                                    {{ __('Set checkpoint') }}
+                                </button>
+                            </div>
+                            <div class="col-12 col-xl-4">
+                                <h3 class="h6">{{ __('Investments') }}</h3>
+                                <dl class="row mb-2" data-reconcile-section="investment"></dl>
+                                <button type="button" class="btn btn-sm btn-outline-primary" data-checkpoint-type="investment">
+                                    <i class="fa-solid fa-bookmark"></i>
+                                    {{ __('Set checkpoint') }}
+                                </button>
+                            </div>
+                            <div class="col-12 col-xl-4">
+                                <h3 class="h6">{{ __('Total') }}</h3>
+                                <dl class="row mb-2" data-reconcile-section="total"></dl>
+                                <button type="button" class="btn btn-sm btn-outline-primary" data-checkpoint-type="total">
+                                    <i class="fa-solid fa-bookmark"></i>
+                                    {{ __('Set checkpoint') }}
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="mt-3">
+                            <button class="btn btn-sm btn-outline-secondary collapsed" type="button"
+                                data-coreui-toggle="collapse" data-coreui-target="#advancedReconcileHoldings">
+                                <i class="fa-solid fa-layer-group"></i>
+                                {{ __('Investment holdings') }}
+                            </button>
+                            <div class="collapse mt-2" id="advancedReconcileHoldings">
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-bordered align-middle mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>{{ __('Investment') }}</th>
+                                                <th>{{ __('Open qty') }}</th>
+                                                <th>{{ __('Close qty') }}</th>
+                                                <th>{{ __('Buys') }}</th>
+                                                <th>{{ __('Sells') }}</th>
+                                                <th>{{ __('Open price') }}</th>
+                                                <th>{{ __('Close price') }}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="advancedReconcileHoldingsBody">
+                                            <tr>
+                                                <td colspan="7"><i class="fa fa-fw fa-spinner fa-spin"></i></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="card left-control-panel-toggle-card">
                 <div class="card-header d-flex justify-content-between left-control-panel-toggle-header">
                     <div class="card-title">

--- a/resources/views/accounts/show.blade.php
+++ b/resources/views/accounts/show.blade.php
@@ -186,6 +186,8 @@
                                                 <th>{{ __('Sells') }}</th>
                                                 <th>{{ __('Open price') }}</th>
                                                 <th>{{ __('Close price') }}</th>
+                                                <th>{{ __('Open value') }}</th>
+                                                <th>{{ __('Close value') }}</th>
                                             </tr>
                                         </thead>
                                         <tbody id="advancedReconcileHoldingsBody">

--- a/resources/views/reports/advanced-reconcile.blade.php
+++ b/resources/views/reports/advanced-reconcile.blade.php
@@ -1,0 +1,45 @@
+@extends('template.layouts.page')
+
+@section('title_postfix', __('Advanced reconcile'))
+
+@section('content_container_classes', 'container-fluid')
+
+@section('content_header', __('Advanced reconcile'))
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card mb-3">
+            <div class="card-header d-flex flex-wrap gap-2 justify-content-between align-items-center">
+                <div class="card-title mb-0">{{ __('Account reconciliation dashboard') }}</div>
+                <div class="d-flex flex-wrap gap-2 align-items-center">
+                    <select class="form-select form-select-sm w-auto" id="advancedReconcileType">
+                        <option value="total">{{ __('Total') }}</option>
+                        <option value="cash">{{ __('Cash') }}</option>
+                        <option value="investment">{{ __('Investment') }}</option>
+                    </select>
+                    <select class="form-select form-select-sm w-auto" id="advancedReconcileDisplay">
+                        <option value="status">{{ __('See status') }}</option>
+                        <option value="balance">{{ __('See closing balance') }}</option>
+                    </select>
+                    <button type="button" class="btn btn-sm btn-primary" id="advancedReconcileReload">
+                        <i class="fa-solid fa-arrows-rotate"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm table-bordered align-middle" id="advancedReconcileDashboard">
+                        <thead></thead>
+                        <tbody>
+                            <tr>
+                                <td><i class="fa fa-fw fa-spinner fa-spin"></i></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@stop

--- a/resources/views/template/components/navigation.blade.php
+++ b/resources/views/template/components/navigation.blade.php
@@ -81,6 +81,11 @@
                 text="{{ __('Cash flow') }}"
             />
             <x-nav-link
+                href="{{ route('reports.advanced-reconcile') }}"
+                iconClasses="fa-solid fa-scale-balanced"
+                text="{{ __('Advanced reconcile') }}"
+            />
+            <x-nav-link
                 href="{{ route('reports.budgetchart') }}"
                 iconClasses="fa-solid fa-chart-line"
                 text="{{ __('Budget chart') }}"

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\API\AccountApiController;
+use App\Http\Controllers\API\AccountBalanceCheckpointApiController;
 use App\Http\Controllers\API\AccountEntityApiController;
 use App\Http\Controllers\API\AccountGroupApiController;
 use App\Http\Controllers\API\AiDocumentApiController;
@@ -140,6 +141,12 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
     Route::get('/accounts/{accountEntity}/balance', [AccountApiController::class, 'getAccountBalance'])
         ->whereNumber('accountEntity')
         ->name('accounts.balance.show');
+    Route::get('/accounts/{accountEntity}/advanced-reconcile', [AccountBalanceCheckpointApiController::class, 'accountSummary'])
+        ->whereNumber('accountEntity')
+        ->name('accounts.advanced-reconcile.show');
+    Route::post('/accounts/{accountEntity}/balance-checkpoints', [AccountBalanceCheckpointApiController::class, 'store'])
+        ->whereNumber('accountEntity')
+        ->name('accounts.balance-checkpoints.store');
     Route::get('/accounts/{accountEntity}', [AccountApiController::class, 'getItem'])
         ->whereNumber('accountEntity')
         ->name('accounts.show');
@@ -262,6 +269,8 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
         ->name('reports.budget-chart');
     Route::get('/reports/cashflow', [ReportApiController::class, 'getCashflowData'])
         ->name('reports.cashflow');
+    Route::get('/reports/advanced-reconcile', [AccountBalanceCheckpointApiController::class, 'dashboard'])
+        ->name('reports.advanced-reconcile');
     Route::get(
         '/reports/waterfall/{transactionType}/{dataType}/{year}/{month?}',
         [ReportApiController::class, 'getCategoryWaterfallData']

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -227,6 +227,11 @@ Breadcrumbs::for('reports.investment_timeline', function (BreadcrumbTrail $trail
     $trail->push(__('Investments'), route('investments.index'));
     $trail->push(__('Investment timeline'), route('reports.investment_timeline'));
 });
+Breadcrumbs::for('reports.advanced-reconcile', function (BreadcrumbTrail $trail) {
+    $trail->parent('home');
+    $trail->push(__('Reports'), route('investments.index'));
+    $trail->push(__('Advanced Reconcile'), route('reports.advanced-reconcile'));
+});
 
 // Search
 Breadcrumbs::for('search', function (BreadcrumbTrail $trail) {

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -229,7 +229,7 @@ Breadcrumbs::for('reports.investment_timeline', function (BreadcrumbTrail $trail
 });
 Breadcrumbs::for('reports.advanced-reconcile', function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push(__('Reports'), route('investments.index'));
+    $trail->push(__('Reports'));
     $trail->push(__('Advanced Reconcile'), route('reports.advanced-reconcile'));
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,6 +105,8 @@ Route::resource('transactions', TransactionController::class)
 Route::get('/reports/cashflow', [ReportController::class, 'cashFlow'])->name('reports.cashflow');
 Route::get('/reports/budgetchart', [ReportController::class, 'budgetChart'])->name('reports.budgetchart');
 Route::get('/reports/schedule', [ReportController::class, 'getSchedules'])->name('report.schedules');
+Route::get('/reports/advanced-reconcile', [ReportController::class, 'advancedReconcile'])
+    ->name('reports.advanced-reconcile');
 Route::get('/reports/transactions', [ReportController::class, 'transactionsByCriteria'])
     ->name('reports.transactions');
 Route::get('/reports/timeline', [ReportController::class, 'investmentTimeline'])->name('reports.investment_timeline');

--- a/tests/Feature/API/AdvancedReconcileApiTest.php
+++ b/tests/Feature/API/AdvancedReconcileApiTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Tests\Feature\API;
+
+use App\Enums\TransactionType;
+use App\Models\Account;
+use App\Models\AccountEntity;
+use App\Models\Currency;
+use App\Models\Investment;
+use App\Models\InvestmentPrice;
+use App\Models\Payee;
+use App\Models\Transaction;
+use App\Models\TransactionDetailInvestment;
+use App\Models\TransactionDetailStandard;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdvancedReconcileApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private AccountEntity $account;
+    private AccountEntity $payee;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow('2026-07-15');
+
+        $this->user = User::factory()->create();
+        $currency = Currency::factory()
+            ->for($this->user)
+            ->fromIsoCodes(['USD'])
+            ->create(['base' => true]);
+
+        $this->account = AccountEntity::factory()
+            ->for($this->user)
+            ->for(Account::factory()->withUser($this->user)->create([
+                'currency_id' => $currency->id,
+                'opening_balance' => 100,
+            ]), 'config')
+            ->create(['active' => true]);
+
+        $this->payee = AccountEntity::factory()
+            ->for($this->user)
+            ->for(Payee::factory()->withUser($this->user), 'config')
+            ->create(['active' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_user_can_summarize_cash_reconciliation_and_save_matching_checkpoint(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->createWithdrawal('2026-07-03', 30);
+        $this->createDeposit('2026-07-05', 50);
+
+        $summaryResponse = $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
+            'accountEntity' => $this->account,
+            'date_from' => '2026-07-01',
+            'date_to' => '2026-07-31',
+        ]));
+
+        $summaryResponse->assertOk();
+        $summaryResponse->assertJsonPath('cash.opening_balance', 100);
+        $summaryResponse->assertJsonPath('cash.total_withdrawals', 30);
+        $summaryResponse->assertJsonPath('cash.total_deposits', 50);
+        $summaryResponse->assertJsonPath('cash.balance', 120);
+        $summaryResponse->assertJsonPath('cash.status', 'no_checkpoint');
+
+        $checkpointResponse = $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'cash',
+            'balance' => 120,
+            'note' => 'July statement',
+        ]);
+
+        $checkpointResponse->assertCreated();
+        $this->assertDatabaseHas('account_balance_checkpoints', [
+            'account_entity_id' => $this->account->id,
+            'checkpoint_type' => 'cash',
+            'balance' => 120,
+            'note' => 'July statement',
+        ]);
+
+        $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
+            'accountEntity' => $this->account,
+            'date_from' => '2026-07-01',
+            'date_to' => '2026-07-31',
+        ]))
+            ->assertOk()
+            ->assertJsonPath('cash.status', 'matched')
+            ->assertJsonPath('cash.variance', 0);
+    }
+
+    public function test_dashboard_marks_variance_as_reconcile_required(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->createDeposit('2026-07-05', 50);
+
+        $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'cash',
+            'balance' => 200,
+        ])->assertCreated();
+
+        $response = $this->getJson(route('api.v1.reports.advanced-reconcile', [
+            'checkpoint_type' => 'cash',
+            'display' => 'status',
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('rows.0.months.2026-07.status', 'reconcile_required');
+        $response->assertJsonPath('rows.0.months.2026-07.variance', 50);
+    }
+
+    public function test_investment_holdings_include_statement_price_editing_metadata(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $investment = Investment::factory()->withUser($this->user)->create([
+            'currency_id' => $this->account->config->currency_id,
+        ]);
+
+        $this->createInvestmentBuy($investment, '2026-06-15', 10);
+
+        $openingPrice = InvestmentPrice::factory()->create([
+            'investment_id' => $investment->id,
+            'date' => '2026-07-01',
+            'price' => 12.34,
+        ]);
+        InvestmentPrice::factory()->create([
+            'investment_id' => $investment->id,
+            'date' => '2026-07-20',
+            'price' => 15.67,
+        ]);
+
+        $response = $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
+            'accountEntity' => $this->account,
+            'date_from' => '2026-07-01',
+            'date_to' => '2026-07-31',
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('investment.holdings.0.investment_id', $investment->id);
+        $response->assertJsonPath('investment.holdings.0.open_quantity', 10);
+        $response->assertJsonPath('investment.holdings.0.close_quantity', 10);
+        $response->assertJsonPath('investment.holdings.0.open_price', 12.34);
+        $response->assertJsonPath('investment.holdings.0.close_price', 15.67);
+        $response->assertJsonPath('investment.holdings.0.open_stored_price_id', $openingPrice->id);
+        $response->assertJsonPath('investment.holdings.0.close_stored_price_id', null);
+    }
+
+    public function test_user_cannot_save_checkpoint_for_another_users_account(): void
+    {
+        $otherUser = User::factory()->create();
+        Sanctum::actingAs($otherUser);
+
+        $response = $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'cash',
+            'balance' => 120,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    private function createWithdrawal(string $date, float $amount): void
+    {
+        $detail = TransactionDetailStandard::create([
+            'account_from_id' => $this->account->id,
+            'account_to_id' => $this->payee->id,
+            'amount_from' => $amount,
+            'amount_to' => $amount,
+        ]);
+
+        Transaction::create([
+            'date' => $date,
+            'transaction_type' => TransactionType::WITHDRAWAL,
+            'reconciled' => false,
+            'schedule' => false,
+            'budget' => false,
+            'config_type' => 'standard',
+            'config_id' => $detail->id,
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    private function createDeposit(string $date, float $amount): void
+    {
+        $detail = TransactionDetailStandard::create([
+            'account_from_id' => $this->payee->id,
+            'account_to_id' => $this->account->id,
+            'amount_from' => $amount,
+            'amount_to' => $amount,
+        ]);
+
+        Transaction::create([
+            'date' => $date,
+            'transaction_type' => TransactionType::DEPOSIT,
+            'reconciled' => false,
+            'schedule' => false,
+            'budget' => false,
+            'config_type' => 'standard',
+            'config_id' => $detail->id,
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    private function createInvestmentBuy(Investment $investment, string $date, float $quantity): void
+    {
+        $detail = TransactionDetailInvestment::create([
+            'account_id' => $this->account->id,
+            'investment_id' => $investment->id,
+            'quantity' => $quantity,
+            'price' => 10,
+            'commission' => 0,
+            'tax' => 0,
+            'dividend' => null,
+        ]);
+
+        Transaction::create([
+            'date' => $date,
+            'transaction_type' => TransactionType::BUY,
+            'reconciled' => false,
+            'schedule' => false,
+            'budget' => false,
+            'config_type' => 'investment',
+            'config_id' => $detail->id,
+            'cashflow_value' => -100,
+            'user_id' => $this->user->id,
+        ]);
+    }
+}

--- a/tests/Feature/API/AdvancedReconcileApiTest.php
+++ b/tests/Feature/API/AdvancedReconcileApiTest.php
@@ -59,25 +59,24 @@ class AdvancedReconcileApiTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_user_can_summarize_cash_reconciliation_and_save_matching_checkpoint(): void
+    public function test_user_can_summarize_cash_reconciliation_without_checkpoint(): void
     {
         Sanctum::actingAs($this->user);
 
-        $this->createWithdrawal('2026-07-03', 30);
-        $this->createDeposit('2026-07-05', 50);
+        $this->createJulyCashMovements();
 
-        $summaryResponse = $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
-            'accountEntity' => $this->account,
-            'date_from' => '2026-07-01',
-            'date_to' => '2026-07-31',
-        ]));
-
+        $summaryResponse = $this->getJulySummary();
         $summaryResponse->assertOk();
         $summaryResponse->assertJsonPath('cash.opening_balance', 100);
         $summaryResponse->assertJsonPath('cash.total_withdrawals', 30);
         $summaryResponse->assertJsonPath('cash.total_deposits', 50);
         $summaryResponse->assertJsonPath('cash.balance', 120);
         $summaryResponse->assertJsonPath('cash.status', 'no_checkpoint');
+    }
+
+    public function test_user_can_save_matching_cash_checkpoint(): void
+    {
+        Sanctum::actingAs($this->user);
 
         $checkpointResponse = $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
             'accountEntity' => $this->account,
@@ -95,12 +94,23 @@ class AdvancedReconcileApiTest extends TestCase
             'balance' => 120,
             'note' => 'July statement',
         ]);
+    }
 
-        $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
+    public function test_saved_matching_cash_checkpoint_marks_summary_as_matched(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->createJulyCashMovements();
+        $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
             'accountEntity' => $this->account,
-            'date_from' => '2026-07-01',
-            'date_to' => '2026-07-31',
-        ]))
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'cash',
+            'balance' => 120,
+            'note' => 'July statement',
+        ])->assertCreated();
+
+        $this->getJulySummary()
             ->assertOk()
             ->assertJsonPath('cash.status', 'matched')
             ->assertJsonPath('cash.variance', 0);
@@ -181,6 +191,65 @@ class AdvancedReconcileApiTest extends TestCase
         ]);
 
         $response->assertForbidden();
+    }
+
+    public function test_checkpoint_type_must_be_valid_when_saving_checkpoint(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'other',
+            'balance' => 120,
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('checkpoint_type');
+    }
+
+    public function test_balance_is_required_when_saving_checkpoint(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => '2026-07-31',
+            'checkpoint_type' => 'cash',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('balance');
+    }
+
+    public function test_checkpoint_date_must_be_a_valid_date_when_saving_checkpoint(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->postJson(route('api.v1.accounts.balance-checkpoints.store', [
+            'accountEntity' => $this->account,
+        ]), [
+            'checkpoint_date' => 'not-a-date',
+            'checkpoint_type' => 'cash',
+            'balance' => 120,
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('checkpoint_date');
+    }
+
+    private function getJulySummary(): \Illuminate\Testing\TestResponse
+    {
+        return $this->getJson(route('api.v1.accounts.advanced-reconcile.show', [
+            'accountEntity' => $this->account,
+            'date_from' => '2026-07-01',
+            'date_to' => '2026-07-31',
+        ]));
+    }
+
+    private function createJulyCashMovements(): void
+    {
+        $this->createWithdrawal('2026-07-03', 30);
+        $this->createDeposit('2026-07-05', 50);
     }
 
     private function createWithdrawal(string $date, float $amount): void

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Account;
+use App\Models\AccountBalanceCheckpoint;
 use App\Models\AccountEntity;
 use App\Models\AccountGroup;
 use App\Models\Currency;
@@ -130,6 +131,31 @@ class AccountTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertViewIs('accounts.index');
+    }
+
+    public function test_account_details_exposes_checkpoint_windows_for_date_presets(): void
+    {
+        $account = $this->createAccountAndUser();
+
+        AccountBalanceCheckpoint::factory()
+            ->forAccount($account)
+            ->create(['checkpoint_date' => '2026-01-31', 'checkpoint_type' => 'cash']);
+        AccountBalanceCheckpoint::factory()
+            ->forAccount($account)
+            ->create(['checkpoint_date' => '2026-02-28', 'checkpoint_type' => 'cash']);
+        AccountBalanceCheckpoint::factory()
+            ->forAccount($account)
+            ->create(['checkpoint_date' => '2026-03-31', 'checkpoint_type' => 'total']);
+
+        $response = $this->actingAs($account->user)->get(route("{$this->base_route}.show", [
+            'account_entity' => $account,
+        ]));
+
+        $response->assertOk();
+        $response->assertSee('checkpointWindow:2026-02-28', false);
+        $response->assertSee('2026-02-01 - 2026-02-28', false);
+        $response->assertSee('checkpointWindow:2026-03-31', false);
+        $response->assertSee('2026-03-01 - 2026-03-31', false);
     }
 
     public function test_user_can_access_create_form(): void


### PR DESCRIPTION
This is my first commit as part of Reconcile Master, A set of additional functionality to aid in making reference points back based on the account balance or investment value on a given day. This should assist in the reconcillation between statements and Yaffa.

This first commit is to get the table in place and bring in a window to save checkpoints



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Advanced reconcile” report page with month-by-month status/variance, type/display filters, and drill-down links.
  * Added an account “Advanced reconcile” panel (Cash, Investments, Total) with checkpoint saving and investment holdings with “missing price” handling.
  * Added an investment price “Set price” modal (price-at-date or value-at-date) and new checkpoint windows date presets.
  * Added API endpoints for reconcile summaries, dashboard data, and checkpoint storage.
* **Documentation**
  * Documented Advanced Reconcile rules, valuation behavior, and checkpoint semantics.
* **Tests**
  * Expanded feature/API test coverage for reconciliation, dashboard variance, authorization, and request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->