### PR TITLE
feat(docker): make the self-hosted container self-configuring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Version control history -- large and irrelevant to the build.
+.git
+.gitattributes
+
+# Rebuilt inside the image (composer install / npm ci); shipping a local copy
+# is wasteful at best and can inject a mismatched local install at worst.
+/vendor
+/node_modules
+
+# Secrets and local environment overrides -- must never end up in a shipped image.
+.env
+.env.backup
+.env.*.local
+
+# IDE and editor metadata
+/.idea
+/.vscode
+/.continue
+/.nova
+
+# Laravel IDE helper artifacts
+_ide_helper.php
+_ide_helper_models.php
+.phpstorm.meta.php
+
+# Test and tooling caches
+/.phpunit.cache
+.phpunit.result.cache
+.pint.cache
+.eslintcache
+.stylelintcache
+
+# OS noise
+.DS_Store
+Thumbs.db
+npm-debug.log
+yarn-error.log
+
+# Generated storage content: logs, debugbar captures, cached views/sessions, local
+# exports. The image only needs the directory skeleton (preserved by the .gitignore
+# placeholders each subdirectory tracks); the actual runtime content is seeded fresh
+# into the yaffa_storage volume on first container start, and a local export could
+# contain real data that has no business being baked into a shipped image.
+storage/*.sql
+storage/logs/*.log
+storage/debugbar/*
+storage/framework/cache/data/*
+storage/framework/sessions/*
+storage/framework/testing/*
+storage/framework/views/*
+storage/pail/*
+
+# Generated frontend build output -- the assets stage produces its own via `npm run build`.
+/public/build
+/public/hot
+/public/storage

--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,12 @@
 ###############################
 
 # Encryption key used to encrypt session and other data
-# You can use the "php artisan key:generate" command to generate a random key, which will overwrite this value
+# You can use the "php artisan key:generate" command to generate a random key, which will overwrite this value.
+# If you use the official Docker image (docker/docker-compose.yml), leave this empty: the container
+# generates a key on first boot and persists it in the storage volume, so no manual step is needed.
 # Make sure to keep this key secret, and don't share it with anyone.
 # Also, don't change it after you have started using the application.
-APP_KEY=PleaseReplaceThisWithARandomStringOf32Chars
+APP_KEY=
 
 ### Database configuration ###
 DB_CONNECTION=mysql

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable redis \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install \
-    pdo pdo_mysql mbstring zip xml gd exif
+    pdo pdo_mysql mbstring zip xml gd exif bcmath
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,8 +58,10 @@ COPY ./docker/php-logging.ini /usr/local/etc/php/conf.d/zz-php-logging.ini
 # Install dependencies via Composer
 RUN composer install --no-dev --no-interaction --no-progress
 
-# Set permissions for the app files (to ensure Apache can access the app)
-RUN chown -R www-data:www-data /var/www/html \
+# Only storage/ and bootstrap/cache/ need to be writable by Apache at runtime -- the rest of
+# the app (notably vendor/, 50k+ files) only needs to stay readable, which COPY already leaves
+# it as. Scoping the chown to match the chmod avoids recursing over the whole tree.
+RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache \
     && chmod -R 755 /var/www/html/storage /var/www/html/bootstrap/cache
 
 # Replace the default Apache vhost with one that points at Laravel's public/ directory.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     env_file:
       - .env
     environment:
-      RUNS_SCHEDULER: FALSE
+      RUNS_SCHEDULER: 'FALSE'
       # Stream Laravel application logs to the container's stderr so they show up
       # in `docker logs`. Overrides LOG_STACK from .env. Remove this line if you
       # prefer file-based logging into the yaffa_storage volume.
@@ -64,7 +64,7 @@ services:
     env_file:
       - .env
     environment:
-      RUNS_SCHEDULER: TRUE
+      RUNS_SCHEDULER: 'TRUE'
       # See note in the `app` service above.
       LOG_STACK: stderr
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,7 +61,6 @@ services:
   scheduler:
     image: kantorge/yaffa:latest
     container_name: yaffa_scheduler
-    entrypoint: ['/usr/bin/supervisord', '-c', '/etc/supervisord.conf']
     env_file:
       - .env
     environment:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,17 +11,45 @@ if [ -n "$DB_HOST" ]; then
   done
 fi
 
-# Run various Laravel maintenance scripts
-php artisan down || true
-php artisan migrate --force
-php artisan app:import:sync-system-profiles --no-interaction
-php artisan optimize:clear
-php artisan optimize
-php artisan up
+# Auto-generate APP_KEY on first boot if it wasn't supplied via the environment.
+# The key is persisted in the storage volume (shared with the scheduler container)
+# so restarts and container recreation keep using the same key instead of
+# invalidating existing sessions / encrypted data.
+if [ -z "$APP_KEY" ]; then
+  APP_KEY_FILE="/var/www/html/storage/app/.app_key"
+  if [ -f "$APP_KEY_FILE" ]; then
+    APP_KEY=$(cat "$APP_KEY_FILE")
+  else
+    echo "No APP_KEY set, generating one..."
+    APP_KEY=$(php artisan key:generate --show --no-interaction)
+    mkdir -p "$(dirname "$APP_KEY_FILE")"
+    echo -n "$APP_KEY" > "$APP_KEY_FILE"
+  fi
+  export APP_KEY
+fi
+
+# Only the main app container runs migrations/optimization; the scheduler
+# container (RUNS_SCHEDULER=TRUE) waits for it via depends_on: service_healthy,
+# so by the time it starts the schema is already up to date.
+if [ "$RUNS_SCHEDULER" != "TRUE" ]; then
+  # migrate --force is safe to run on every boot: Laravel tracks applied
+  # migrations and skips them, so this is a no-op after the first run.
+  php artisan down || true
+  php artisan migrate --force
+  php artisan app:import:sync-system-profiles --no-interaction
+  php artisan optimize:clear
+  php artisan optimize
+  php artisan up
+fi
 
 echo "Adjusting storage permissions..."
 chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
 chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache
 
-echo "Startup complete. Launching Apache..."
-exec apache2-foreground
+if [ "$RUNS_SCHEDULER" = "TRUE" ]; then
+  echo "Startup complete. Launching scheduler/queue supervisor..."
+  exec /usr/bin/supervisord -c /etc/supervisord.conf
+else
+  echo "Startup complete. Launching Apache..."
+  exec apache2-foreground
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,15 +15,20 @@ fi
 # The key is persisted in the storage volume (shared with the scheduler container)
 # so restarts and container recreation keep using the same key instead of
 # invalidating existing sessions / encrypted data.
+APP_KEY_FILE="/var/www/html/storage/app/.app_key"
 if [ -z "$APP_KEY" ]; then
-  APP_KEY_FILE="/var/www/html/storage/app/.app_key"
-  if [ -f "$APP_KEY_FILE" ]; then
+  if [ -s "$APP_KEY_FILE" ]; then
     APP_KEY=$(cat "$APP_KEY_FILE")
   else
     echo "No APP_KEY set, generating one..."
     APP_KEY=$(php artisan key:generate --show --no-interaction)
     mkdir -p "$(dirname "$APP_KEY_FILE")"
-    echo -n "$APP_KEY" > "$APP_KEY_FILE"
+    # Write to a temp file and rename into place so a killed/interrupted boot
+    # never leaves a truncated key file for the next boot to blindly reuse.
+    APP_KEY_TMP="$APP_KEY_FILE.$$.tmp"
+    printf '%s' "$APP_KEY" > "$APP_KEY_TMP"
+    chmod 600 "$APP_KEY_TMP"
+    mv "$APP_KEY_TMP" "$APP_KEY_FILE"
   fi
   export APP_KEY
 fi
@@ -45,6 +50,10 @@ fi
 echo "Adjusting storage permissions..."
 chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
 chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache
+# The broad chmod above would otherwise leave the encryption key group/world-readable.
+if [ -f "$APP_KEY_FILE" ]; then
+  chmod 600 "$APP_KEY_FILE"
+fi
 
 if [ "$RUNS_SCHEDULER" = "TRUE" ]; then
   echo "Startup complete. Launching scheduler/queue supervisor..."


### PR DESCRIPTION
## Summary
- Auto-generate `APP_KEY` on first boot when unset, persisted in the `yaffa_storage` volume so restarts/recreates reuse the same key instead of invalidating sessions and encrypted data.
- Unify the `scheduler` container onto the same `entrypoint.sh` (dropping its `entrypoint:` override in `docker-compose.yml`), branching on `RUNS_SCHEDULER`: it now resolves `APP_KEY` too, but skips `migrate`/`optimize` (already handled by the `app` container it depends on) and execs `supervisord` instead of Apache.
- Default `APP_KEY` to empty in `.env.example` instead of a fake placeholder string, so leaving it blank is the documented zero-edit path for the Docker image.

Goal: `docker compose up -d` with zero `.env` edits produces a working instance.

## Test plan
- [x] `sh -n docker/entrypoint.sh` — syntax check
- [x] `docker compose -f docker/docker-compose.yml config` — resolves cleanly, confirms `scheduler` no longer has an `entrypoint:` override and falls through to the image's default entrypoint
- [x] Offline shell self-check running the real `entrypoint.sh` with stubbed `php`/`chown`/`apache2-foreground`/`supervisord`, covering: key generated + persisted on first boot; key reused (not regenerated) on restart; explicit `APP_KEY` bypasses generation; scheduler container skips migrations and launches `supervisord` instead of Apache
- [ ] Full `docker build` + `docker compose up -d` end-to-end (blocked in the dev sandbox by no npm registry access for the asset build stage — recommend a real end-to-end smoke test before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker deployments can now automatically generate and persist an application key when one isn’t provided.
  * Scheduler and queue containers now start with their appropriate background processes.
* **Bug Fixes**
  * Database migrations and maintenance tasks are limited to the main application container, preventing duplicate execution in scheduler containers.
  * Improved container startup behavior for Apache-based application services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->