### PR TITLE
feat(docker): ship a real HTTPS/Caddy reverse-proxy profile

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -36,6 +36,9 @@ jobs:
           sed -i 's|^DB_HOST=.*|DB_HOST=db|' docker/.env
           sed -i "s|^APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|" docker/.env
 
+      - name: Validate https profile (Caddy) wiring
+        run: docker compose -f docker/docker-compose.yml --profile https config -q
+
       - name: Start core services
         run: docker compose -f docker/docker-compose.yml up -d db redis app
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -78,6 +78,8 @@ docker compose up -d app scheduler
 
 The container entrypoint automatically runs migrations, clears caches, and rebuilds assets on startup.
 
+**Caddy reverse proxy is now a Compose profile.** `docker/docker-compose.yml`'s Caddy service is no longer a commented-out block you manually uncomment — it's gated behind the `https` Compose profile, started with `docker compose --profile https up -d`. If you previously uncommented the old Caddy block by hand, pulling the new `docker-compose.yml` will conflict with (or silently discard) that edit; re-apply your Caddyfile/domain setup and switch to the `--profile https` flag instead of a manual edit. If you run with this profile, also set `APP_PORT` in your `.env` (e.g. `APP_PORT=127.0.0.1:8080`) so the `app` service doesn't also try to bind host port 80 alongside Caddy — see the comments in `docker-compose.yml` for details.
+
 ##### Source code users
 
 ```bash

--- a/docker-smoke-test.sh
+++ b/docker-smoke-test.sh
@@ -30,6 +30,9 @@ cp .env.example docker/.env
 sed -i 's|^DB_HOST=.*|DB_HOST=db|' docker/.env
 sed -i "s|^APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|" docker/.env
 
+print_step "Validating https profile (Caddy) wiring"
+docker compose -f "$COMPOSE_FILE" --profile https config -q
+
 print_step "Starting core services"
 docker compose -f "$COMPOSE_FILE" up -d db redis app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,32 +1,39 @@
 services:
   # Caddy is a web server that can automatically obtain and renew SSL certificates from Let's Encrypt (https://caddyserver.com/)
-  # It is used as a reverse proxy to handle HTTPS traffic and redirect HTTP to HTTPS
-  # If you need this functionality, then uncomment the following lines and adjust the Caddyfile accordingly
-  # (Create a Caddyfile in the same directory as this docker-compose.yml file, or download it from Yaffa's GitHub repository)
-  # You also need to adjust the port settings of the app container to listen to the port that Caddy is forwarding to. Also, enable the Caddy dependency in the app container.
-  # caddy:
-  #   image: caddy:latest
-  #   container_name: yaffa_caddy
-  #   restart: unless-stopped
-  #   ports:
-  #     - "80:80"    # HTTP traffic
-  #     - "443:443"  # HTTPS traffic
-  #     # - "8400:8400"  # Custom port to access Yaffa. Adjust the Caddyfile accordingly
-  #   volumes:
-  #     - ./Caddyfile:/etc/caddy/Caddyfile  # Caddyfile configuration
-  #     - caddy_data:/data                  # SSL certificates & ACME storage
-  #     - caddy_config:/config              # Caddy configurations
-  #   networks:
-  #     - yaffa-network
+  # It is used as a reverse proxy to handle HTTPS traffic and redirect HTTP to HTTPS.
+  # Gated behind the "https" Compose profile, so it only starts with:
+  #   docker compose --profile https up -d
+  # Create a Caddyfile in the same directory as this docker-compose.yml file, or download it from Yaffa's GitHub repository.
+  # When running with this profile, set APP_PORT in your .env (see the app service below) so
+  # Caddy is the only service publishing ports 80/443 on the host.
+  caddy:
+    image: caddy:latest
+    container_name: yaffa_caddy
+    restart: unless-stopped
+    profiles:
+      - https
+    ports:
+      - '80:80' # HTTP traffic
+      - '443:443' # HTTPS traffic
+      # - "8400:8400"  # Custom port to access Yaffa. Adjust the Caddyfile accordingly
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile # Caddyfile configuration
+      - caddy_data:/data # SSL certificates & ACME storage
+      - caddy_config:/config # Caddy configurations
+    networks:
+      - yaffa-network
 
   # This is the main Yaffa app container
   app:
     image: kantorge/yaffa:latest
     container_name: yaffa_app
     ports:
-      # Select one of the following options to expose Yaffa to the world
-      - '80:80' # Expose YAFFA on port 80 directly, if you don't use Caddy
-      #- "80" # Expose the app on port 80, Caddy will handle opening it to the world
+      # Default: expose Yaffa directly on host port 80.
+      # If you start the "https" profile (Caddy binds host ports 80/443), set
+      # APP_PORT in your .env to avoid a conflict, e.g. APP_PORT=127.0.0.1:8080
+      # to keep a private, direct-access port, or APP_PORT=127.0.0.1: to disable
+      # host publishing entirely and only reach the app through Caddy.
+      - '${APP_PORT:-80}:80'
     env_file:
       - .env
     environment:
@@ -38,9 +45,6 @@ services:
     volumes:
       - yaffa_storage:/var/www/html/storage # Yaffa storage for logs and planned future upload features
     depends_on:
-      # Uncomment the following line if you use Caddy as a reverse proxy
-      # caddy:
-      #   condition: service_started
       # Uncomment the following lines if you use Tesseract OCR from the Docker sidecar
       # tesseract:
       #   condition: service_healthy


### PR DESCRIPTION
## Summary
- Replace the commented-out Caddy block in `docker/docker-compose.yml` with a real service gated behind the `https` Compose profile — `docker compose up -d` still starts only app/db/redis/scheduler, `docker compose --profile https up -d` also starts Caddy for automatic HTTPS.
- Make the `app` service's host port configurable via `APP_PORT` (defaults to `80`, unchanged) so it can be moved off 80/443 when Caddy owns those ports.
- Document the change for 3.x→4.x upgraders in `UPGRADE.md`, and add a `docker compose --profile https config -q` validation step to `docker-smoke-test.sh` and its GitHub Actions workflow to catch profile-wiring regressions.

## Test plan
- [x] `docker compose -f docker/docker-compose.yml config --services` → excludes `caddy` (default/no-profile)
- [x] `docker compose -f docker/docker-compose.yml --profile https config --services` → includes `caddy`
- [x] Confirmed `app` cannot `depends_on: caddy` without breaking the default (no-profile) startup path — Compose errors on "depends on undefined service" — so that dependency was intentionally left out; Caddy's `reverse_proxy` retries the upstream on its own.
- [ ] Full `docker-smoke-test.sh` run (build image + boot stack) — attempted locally but blocked by an unrelated transient `codeload.github.com` 429 during `composer install`; should be re-verified in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTPS support for Docker deployments through the Caddy profile.
  * Caddy now provides HTTP and HTTPS access with certificate and configuration support.
  * Application port mapping can be customized when HTTPS is enabled.

* **Documentation**
  * Updated upgrade instructions with HTTPS setup steps and port configuration guidance.

* **Tests**
  * Docker smoke tests now validate the HTTPS configuration before starting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->